### PR TITLE
Copy chrom along with position and *_nuc.

### DIFF
--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -921,13 +921,7 @@ Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::get_tree_copy(Mutation_An
               auto n1 = dfs1[k];
               auto n2 = dfs2[k];
               for (auto m: n1->mutations) {
-                Mutation m2;
-                m2.chrom = m.chrom;
-                m2.position = m.position;
-                m2.ref_nuc = m.ref_nuc;
-                m2.par_nuc = m.par_nuc;
-                m2.mut_nuc = m.mut_nuc;
-                m2.is_missing = m.is_missing;
+                Mutation m2 = m.copy();
                 n2->add_mutation(m2);
                 }
               }

--- a/src/mutation_annotated_tree.hpp
+++ b/src/mutation_annotated_tree.hpp
@@ -35,6 +35,16 @@ namespace Mutation_Annotated_Tree {
         inline bool operator< (const Mutation& m) const {
             return ((*this).position < m.position);
         }
+        inline Mutation copy() const {
+            Mutation m;
+            m.chrom = chrom;
+            m.position = position;
+            m.ref_nuc = ref_nuc;
+            m.par_nuc = par_nuc;
+            m.mut_nuc = mut_nuc;
+            m.is_missing = is_missing;
+            return m;
+        }
         Mutation () {
             chrom = "";
             is_missing = false;

--- a/src/usher.cpp
+++ b/src/usher.cpp
@@ -883,11 +883,7 @@ int main(int argc, char** argv) {
 
                                 // Compute current best node branch mutations
                                 for (auto m1: best_node->mutations) {
-                                    MAT::Mutation m;
-                                    m.position = m1.position;
-                                    m.ref_nuc = m1.ref_nuc;
-                                    m.par_nuc = m1.par_nuc;
-                                    m.mut_nuc = m1.mut_nuc;
+                                    MAT::Mutation m = m1.copy();
                                     curr_l1_mut.emplace_back(m);
                                 }
                                 // Clear mutations on the best node branch which
@@ -906,11 +902,7 @@ int main(int argc, char** argv) {
                                         }
                                     }
                                     if (!found) {
-                                        MAT::Mutation m;
-                                        m.position = m1.position;
-                                        m.ref_nuc = m1.ref_nuc;
-                                        m.par_nuc = m1.par_nuc;
-                                        m.mut_nuc = m1.mut_nuc;
+                                        MAT::Mutation m = m1.copy();
                                         l1_mut.emplace_back(m);
                                     }
                                 }
@@ -921,22 +913,14 @@ int main(int argc, char** argv) {
                                         if (m1.position == m2.position) {
                                             if (m1.mut_nuc == m2.mut_nuc) {
                                                 found = true;
-                                                MAT::Mutation m;
-                                                m.position = m1.position;
-                                                m.ref_nuc = m1.ref_nuc;
-                                                m.par_nuc = m1.par_nuc;
-                                                m.mut_nuc = m1.mut_nuc;
+                                                MAT::Mutation m = m1.copy();
                                                 common_mut.emplace_back(m);
                                                 break;
                                             }
                                         }
                                     }
                                     if (!found) {
-                                        MAT::Mutation m;
-                                        m.position = m1.position;
-                                        m.ref_nuc = m1.ref_nuc;
-                                        m.par_nuc = m1.par_nuc;
-                                        m.mut_nuc = m1.mut_nuc;
+                                        MAT::Mutation m = m1.copy();
                                         l2_mut.emplace_back(m);
                                     }
                                 }
@@ -963,11 +947,7 @@ int main(int argc, char** argv) {
                                 std::vector<MAT::Mutation> curr_l1_mut;
 
                                 for (auto m1: best_node->mutations) {
-                                    MAT::Mutation m;
-                                    m.position = m1.position;
-                                    m.ref_nuc = m1.ref_nuc;
-                                    m.par_nuc = m1.par_nuc;
-                                    m.mut_nuc = m1.mut_nuc;
+                                    MAT::Mutation m = m1.copy();
                                     curr_l1_mut.emplace_back(m);
                                 }
 
@@ -982,11 +962,7 @@ int main(int argc, char** argv) {
                                         }
                                     }
                                     if (!found) {
-                                        MAT::Mutation m;
-                                        m.position = m1.position;
-                                        m.ref_nuc = m1.ref_nuc;
-                                        m.par_nuc = m1.par_nuc;
-                                        m.mut_nuc = m1.mut_nuc;
+                                        MAT::Mutation m = m1.copy();
                                         node_mut.emplace_back(m);
                                     }
                                 }


### PR DESCRIPTION
I moved the mutation-copying code in mutation_annotated_tree.cpp's get_tree_copy to Mutation.copy() in mutation_annotated_tree.hpp, and updated usher.cpp to use Mutation.copy instead of just copying position and *_nuc, so that chrom would be copied as well (also is_missing).  Previously when new samples were added and saved to a new protobuf, the new protobuf would have the empty string for chrom of copied mutations.  Then matToVcf would write VCF with empty chrom for some mutations and non-empty chrom for others, when they should have been merged (same chrom).