### PR TITLE
New subcommand structure and condensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,30 @@ Mutation-annotated tree file generated using UShER.
 
 ### Options
 
+#### Annotate
+
+**-i**: Input mutation-annotated tree file (REQUIRED)
+
+**-o**: Output mutation-annotated tree file (REQUIRED)
+
+**-p**: Calculate and store total tree parsimony. 
+
+**-e**: Calculate and store equally parsimonious placements for all samples in the tree.
+
+**-h**: Print help messages
+
+#### Filter
+
+**-i**: Input mutation-annotated tree file (REQUIRED) 
+
+**-o**: Output mutation-annotated tree file (REQUIRED)
+
+**-s**: Use to mask specific samples from the tree. 
+
+**-h**: Print help messages
+
+#### Convert
+
 **-i**: Input mutation-annotated tree file (REQUIRED) 
 
 **-v**: Output VCF file 
@@ -280,18 +304,12 @@ Mutation-annotated tree file generated using UShER.
 
 **-n**: Do not include sample genotype columns in VCF output. Used only with -v
 
-**-p**: Calculate and store total tree parsimony. 
-
-**-e**: Calculate and store equally parsimonious placements for all samples in the tree.
-
-**-s**: Use to mask specific samples from the tree. 
-
 **-h**: Print help messages
 
 ### Usage example
 
 ```
-./build/matUtils -i global_assignments.pb -v global_assignments.vcf -t global_assignments.nh
+./build/matUtils convert -i global_assignments.pb -v global_assignments.vcf -t global_assignments.nh
 ```
 
 ### Output

--- a/src/matUtils.cpp
+++ b/src/matUtils.cpp
@@ -14,6 +14,8 @@ namespace MAT = Mutation_Annotated_Tree;
 
 MAT::Tree restrictSamples (std::string samples_filename, MAT::Tree T) {
     // Load restricted sample names from the input file and add it to the set
+    //BUG WARNING
+    //This does not actually work right now- all samples passed in are caught as missing. 
     std::ifstream infile(samples_filename);
     if (!infile) {
         fprintf(stderr, "ERROR: Could not open the restricted samples file: %s!\n", samples_filename.c_str());
@@ -22,14 +24,10 @@ MAT::Tree restrictSamples (std::string samples_filename, MAT::Tree T) {
     std::unordered_set<std::string> restricted_samples;
     std::string sample;
     while (std::getline(infile, sample)) {
-        std::cerr << "Checking for presence of sample ";
-        std::cerr << sample; //there's some kind of formatting problem with the fprintf statements. using cerr instead
-        std::cerr << "\n";
-        //fprintf(stderr, "Checking for presence of %s sample\n", sample.c_str());
+        fprintf(stderr, "Checking for Sample %s\n", sample.c_str());
         if (T.get_node(sample) == NULL) {
-            std::cerr << "ERROR: Sample ";
-            std::cerr << sample; 
-            std::cerr << " missing in input MAT!\n";
+            fprintf(stderr, "ERROR: Sample missing in input MAT!\n");
+            std::cerr << std::endl;
             exit(1);
         }
         restricted_samples.insert(std::move(sample));

--- a/src/matUtils.cpp
+++ b/src/matUtils.cpp
@@ -13,7 +13,7 @@ namespace MAT = Mutation_Annotated_Tree;
 //Filter subcommands follow
 
 MAT::Tree restrictSamples (std::string samples_filename, MAT::Tree T) {
-    // Load restricted sampl0e names from the input file and add it to the set
+    // Load restricted sample names from the input file and add it to the set
     std::ifstream infile(samples_filename);
     if (!infile) {
         fprintf(stderr, "ERROR: Could not open the restricted samples file: %s!\n", samples_filename.c_str());
@@ -22,8 +22,14 @@ MAT::Tree restrictSamples (std::string samples_filename, MAT::Tree T) {
     std::unordered_set<std::string> restricted_samples;
     std::string sample;
     while (std::getline(infile, sample)) {
+        std::cerr << "Checking for presence of sample ";
+        std::cerr << sample; //there's some kind of formatting problem with the fprintf statements. using cerr instead
+        std::cerr << "\n";
+        //fprintf(stderr, "Checking for presence of %s sample\n", sample.c_str());
         if (T.get_node(sample) == NULL) {
-            fprintf(stderr, "ERROR: Sample %s missing in input MAT!\n", sample.c_str());
+            std::cerr << "ERROR: Sample ";
+            std::cerr << sample; 
+            std::cerr << " missing in input MAT!\n";
             exit(1);
         }
         restricted_samples.insert(std::move(sample));
@@ -634,6 +640,12 @@ void annotate_main(po::parsed_options parsed) {
         fprintf(stderr, "Calculating Total Parsimony\n");
         T.total_parsimony = T.get_parsimony_score();
     }
+    //condense_leaves() expects some samples to ignore. We don't have any such samples
+    //this would be space to add an additional argument containing samples to not recondense
+    //for now, just recondense everything
+    std::vector<std::string> preserve;
+    T.condense_leaves(preserve);
+
     // Store final MAT to output file
     if (output_mat_filename != "") {
         fprintf(stderr, "Saving Final Tree\n");
@@ -676,7 +688,6 @@ po::variables_map parse_filter_command(po::parsed_options parsed) {
     return vm;
 }
 
-
 void filter_main(po::parsed_options parsed) {
     //the filter subcommand prunes data from the protobuf based on some threshold, returning a protobuf file that is smaller than the input
     po::variables_map vm = parse_filter_command(parsed);
@@ -696,7 +707,7 @@ void filter_main(po::parsed_options parsed) {
         T = restrictSamples(samples_filename, T);
     }
     //the filter subcommand will be receiving some additional attention in the near future.
-    
+
     // Store final MAT to output file
     if (output_mat_filename != "") {
         fprintf(stderr, "Saving Final Tree\n");

--- a/src/matUtils.cpp
+++ b/src/matUtils.cpp
@@ -175,78 +175,78 @@ MAT::Tree restrictSamples (std::string samples_filename, MAT::Tree T) {
 //a sample that has several EPPs that are very nearby on the tree will have a small neighborhood size value
 //while a sample that only has two or three EPPs but they are on completely different parts of the tree will have a substantially larger one.
 
-// std::vector<MAT::Node*> get_common_nodes (std::vector<std::vector<MAT::Node*>> nodepaths) {
-//     //to identify common nodes, perform pairwise set intersections repeatedly for all path node vectors
-//     std::vector<MAT::Node*> common_nodes = nodepaths[0];
-//     std::sort(common_nodes.begin(), common_nodes.end()); //needs to be sorted for intersection. These are actually vectors of node POINTERS, so this should be fine.
-//     for (size_t s=1; s<nodepaths.size(); s++) {
-//         std::vector<MAT::Node*> nextint;
-//         std::vector<MAT::Node*> next = nodepaths[s];
-//         std::sort(next.begin(), next.end()); //sort each path
-//         std::set_intersection(common_nodes.begin(), common_nodes.end(), next.begin(), next.end(), std::back_inserter(nextint)); //intersect the values
-//         common_nodes = nextint; //store the intersected vector and move to the next node path vector
-//     }
-//     return common_nodes;
-// }
+std::vector<MAT::Node*> get_common_nodes (std::vector<std::vector<MAT::Node*>> nodepaths) {
+    //to identify common nodes, perform pairwise set intersections repeatedly for all path node vectors
+    std::vector<MAT::Node*> common_nodes = nodepaths[0];
+    std::sort(common_nodes.begin(), common_nodes.end()); //needs to be sorted for intersection. These are actually vectors of node POINTERS, so this should be fine.
+    for (size_t s=1; s<nodepaths.size(); s++) {
+        std::vector<MAT::Node*> nextint;
+        std::vector<MAT::Node*> next = nodepaths[s];
+        std::sort(next.begin(), next.end()); //sort each path
+        std::set_intersection(common_nodes.begin(), common_nodes.end(), next.begin(), next.end(), std::back_inserter(nextint)); //intersect the values
+        common_nodes = nextint; //store the intersected vector and move to the next node path vector
+    }
+    return common_nodes;
+}
 
-// std::vector<float> get_all_distances(MAT::Node* target, std::vector<std::vector<MAT::Node*>> paths){
-//     std::vector<float> distvs;
-//     for (size_t p=0; p<paths.size(); p++) {
-//         //for this path to the common ancestor, count up distances from the start until it is reached
-//         float tdist = 0;
-//         for (size_t i=0;i<paths[p].size();i++) {
-//             if (paths[p][i]->identifier == target->identifier) {
-//                 break; //stop iterating when its reached this common ancestor (remember, path is sorted nearest to root)
-//             tdist += paths[p][i]->branch_length;
-//             }
-//         //then record tdist in distvs
-//         distvs.emplace_back(tdist);
-//         }
-//     }
-//     return distvs;
-// }
+std::vector<float> get_all_distances(MAT::Node* target, std::vector<std::vector<MAT::Node*>> paths){
+    std::vector<float> distvs;
+    for (size_t p=0; p<paths.size(); p++) {
+        //for this path to the common ancestor, count up distances from the start until it is reached
+        float tdist = 0;
+        for (size_t i=0;i<paths[p].size();i++) {
+            if (paths[p][i]->identifier == target->identifier) {
+                break; //stop iterating when its reached this common ancestor (remember, path is sorted nearest to root)
+            tdist += paths[p][i]->branch_length;
+            }
+        //then record tdist in distvs
+        distvs.emplace_back(tdist);
+        }
+    }
+    return distvs;
+}
 
-// size_t get_neighborhood_size(std::vector<MAT::Node*> nodes, MAT::Tree* T) {
-//     //first step for this is collecting the full paths back to the root for all nodes
-//     assert (nodes.size() > 1); //doesn't make sense if there's only one best placement.
-//     std::vector<std::vector<MAT::Node*>> parentvecs;
-//     for (size_t s=0; s<nodes.size(); s++) {
-//         std::vector<MAT::Node*> npath = T->rsearch(nodes[s]->identifier);
-//         parentvecs.emplace_back(npath);
-//     }
-//     //then we need to identify all common elements to all node vectors
-//     std::vector<MAT::Node*> common_nodes = get_common_nodes(parentvecs);
-//     //then for all common nodes, we need to calculate the largest sum of paired distances for all samples to that specific common ancestor
-//     //the smallest of these largest sums is the best neighborhood size value
-//     size_t best_size = T->get_parsimony_score(); //bigger than the biggest maximum limit on neighborhood size. basically a big number
-//     for (size_t s=0; s<common_nodes.size(); s++) {
-//         //get the set of distances between each placement to this common ancestor with the path vectors
-//         std::vector<float> distances = get_all_distances(common_nodes[s], parentvecs);
-//         //now find the biggest sum of shared values for this specific common node
-//         float widest = 0.0;
-//         for (size_t i=0; i<distances.size(); i++) {
-//             for (size_t j=0; j<distances.size(); j++) {
-//                 if (i!=j){
-//                     float spairdist = distances[i] + distances[j];
-//                     if (spairdist > widest){
-//                         widest = spairdist;
-//                     }
-//                 }
-//             }
-//         }
-//         //after that oddness, I now have a value which is the longest path going between any two nodes in the placement set
-//         //which goes through this specific common ancestor
-//         //admittedly this is probably not the fastest way to do this, I should be able to eliminate common ancestors which are directly ancestral to common ancestors between the same complete set without counting them up
-//         //but I'm focusing on results first here
-//         //anyways, assign this longest pair path value to best_size if its smaller than any we've seen for other common ancestors
-//         size_t size_widest = static_cast<size_t>(widest);
-//         if (size_widest < best_size){
-//             best_size = size_widest;
-//         }
-//     }
-//     //at the end, we should be left with the proper neighborhood size value. 
-//     return best_size;
-// }
+size_t get_neighborhood_size(std::vector<MAT::Node*> nodes, MAT::Tree* T) {
+    //first step for this is collecting the full paths back to the root for all nodes
+    assert (nodes.size() > 1); //doesn't make sense if there's only one best placement.
+    std::vector<std::vector<MAT::Node*>> parentvecs;
+    for (size_t s=0; s<nodes.size(); s++) {
+        std::vector<MAT::Node*> npath = T->rsearch(nodes[s]->identifier);
+        parentvecs.emplace_back(npath);
+    }
+    //then we need to identify all common elements to all node vectors
+    std::vector<MAT::Node*> common_nodes = get_common_nodes(parentvecs);
+    //then for all common nodes, we need to calculate the largest sum of paired distances for all samples to that specific common ancestor
+    //the smallest of these largest sums is the best neighborhood size value
+    size_t best_size = T->get_parsimony_score(); //bigger than the biggest maximum limit on neighborhood size. basically a big number
+    for (size_t s=0; s<common_nodes.size(); s++) {
+        //get the set of distances between each placement to this common ancestor with the path vectors
+        std::vector<float> distances = get_all_distances(common_nodes[s], parentvecs);
+        //now find the biggest sum of shared values for this specific common node
+        float widest = 0.0;
+        for (size_t i=0; i<distances.size(); i++) {
+            for (size_t j=0; j<distances.size(); j++) {
+                if (i!=j){
+                    float spairdist = distances[i] + distances[j];
+                    if (spairdist > widest){
+                        widest = spairdist;
+                    }
+                }
+            }
+        }
+        //after that oddness, I now have a value which is the longest path going between any two nodes in the placement set
+        //which goes through this specific common ancestor
+        //admittedly this is probably not the fastest way to do this, I should be able to eliminate common ancestors which are directly ancestral to common ancestors between the same complete set without counting them up
+        //but I'm focusing on results first here
+        //anyways, assign this longest pair path value to best_size if its smaller than any we've seen for other common ancestors
+        size_t size_widest = static_cast<size_t>(widest);
+        if (size_widest < best_size){
+            best_size = size_widest;
+        }
+    }
+    //at the end, we should be left with the proper neighborhood size value. 
+    return best_size;
+}
 
 //okay, here's the functional EPPs finding code.
 MAT::Tree findEPPs (MAT::Tree Tobj) {
@@ -367,22 +367,22 @@ MAT::Tree findEPPs (MAT::Tree Tobj) {
                 //additional metadata value (not even starting to assign it to an attribute yet) is maximum pairwise distance between equally parsimonious placement cluster members
                 //commented out code that was accidentally committed to master
                 //to find this, first we need the nodes.
-                // if (num_best > 1){ //only worth calculating if there's more than one best placement. Otherwise its just 0.
-                //     std::vector<MAT::Node*> best_placements;
-                //     //for every index in best_j_vec, find the corresponding node from dfs
-                //     for (size_t z=0; z<best_j_vec.size(); z++) {
-                //         auto nobj = dfs[best_j_vec[z]];
-                //         best_placements.emplace_back(nobj);
-                //     }
-                //     size_t neighborhood_size = get_neighborhood_size(best_placements, T);
-                //     fprintf(stderr, "Neighborhood Size: %ld", neighborhood_size);
-                // } else {
-                //     fprintf(stderr, "Neighborhood Size: 0");
-                //}
+                if (num_best > 1){ //only worth calculating if there's more than one best placement. Otherwise its just 0.
+                    std::vector<MAT::Node*> best_placements;
+                    //for every index in best_j_vec, find the corresponding node from dfs
+                    for (size_t z=0; z<best_j_vec.size(); z++) {
+                        auto nobj = dfs[best_j_vec[z]];
+                        best_placements.emplace_back(nobj);
+                    }
+                    size_t neighborhood_size = get_neighborhood_size(best_placements, T);
+                    fprintf(stderr, "Neighborhood Size: %ld\n", neighborhood_size);
+                } else {
+                    fprintf(stderr, "Neighborhood Size: 0");
+                }
 
             } else {
                 node->epps = 1;
-                //fprintf(stderr, "Neighborhood Size: 0");
+                fprintf(stderr, "Neighborhood Size: 0");
                 //no mutations for this sample compared to the reference. This means it's leaf off the root/identical to the reference
                 //there's just one place for that, ofc.
             }

--- a/src/matUtils.cpp
+++ b/src/matUtils.cpp
@@ -816,7 +816,7 @@ int main (int argc, char** argv) {
         }
     } catch (...) { //not sure this is the best way to catch it when matUtils is called with no positional arguments.
         fprintf(stderr, "No command selected. Please choose from annotate, filter, or convert and try again.\n");
-        exit(1);
+        exit(0);
     }
     return 0;
 }

--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -718,7 +718,7 @@ size_t Mutation_Annotated_Tree::Tree::get_num_leaves(Node* node) {
     return num_leaves;
 }
 
-Mutation_Annotated_Tree::Node* Mutation_Annotated_Tree::Tree::create_node (std::string const& identifier, float branch_len) {
+Mutation_Annotated_Tree::Node* Mutation_Annotated_Tree::Tree::create_node (std::string const& identifier, float branch_len, int epps) {
     all_nodes.clear();
     Node* n = new Node(identifier, branch_len);
     root = n;
@@ -726,7 +726,7 @@ Mutation_Annotated_Tree::Node* Mutation_Annotated_Tree::Tree::create_node (std::
     return n;
 }
 
-Mutation_Annotated_Tree::Node* Mutation_Annotated_Tree::Tree::create_node (std::string const& identifier, Node* par, float branch_len) {
+Mutation_Annotated_Tree::Node* Mutation_Annotated_Tree::Tree::create_node (std::string const& identifier, Node* par, float branch_len, int epps) {
     Node* n = new Node(identifier, par, branch_len);
     if (all_nodes.find(identifier) != all_nodes.end()) {
         fprintf(stderr, "Error: %s already in the tree!\n", identifier.c_str());
@@ -737,7 +737,7 @@ Mutation_Annotated_Tree::Node* Mutation_Annotated_Tree::Tree::create_node (std::
     return n;
 }
 
-Mutation_Annotated_Tree::Node* Mutation_Annotated_Tree::Tree::create_node (std::string const& identifier, std::string const& parent_id, float branch_len) {
+Mutation_Annotated_Tree::Node* Mutation_Annotated_Tree::Tree::create_node (std::string const& identifier, std::string const& parent_id, float branch_len, int epps) {
     Node* par = all_nodes[parent_id];
     return create_node(identifier, par, branch_len);
 }
@@ -979,7 +979,7 @@ void Mutation_Annotated_Tree::Tree::condense_leaves(std::vector<std::string> mis
             std::string new_node_name = "node_" + std::to_string(1+condensed_nodes.size()) + "_condensed_" + std::to_string(polytomy_nodes.size()) + "_leaves";
             
             auto curr_node = get_node(l1->identifier);
-            auto new_node = create_node(new_node_name, curr_node->parent, l1->branch_length);
+            auto new_node = create_node(new_node_name, curr_node->parent, l1->branch_length, l1->epps);
 
             new_node->clear_mutations();
             
@@ -1008,7 +1008,7 @@ void Mutation_Annotated_Tree::Tree::uncondense_leaves() {
         }
 
         for (size_t s = 1; s < num_samples; s++) {
-            create_node(cn->second[s], par, n->branch_length);
+            create_node(cn->second[s], par, n->branch_length, n->epps);
         }
     }
     condensed_nodes.clear();
@@ -1167,7 +1167,7 @@ Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::get_subtree (const Mutati
             }
             // Add as root of the subtree
             if (subtree_parent == NULL) {
-                Node* new_node = subtree.create_node(n->identifier);
+                Node* new_node = subtree.create_node(n->identifier, -1.0, n->epps);
                 
                 std::vector<Node*> root_to_node = tree.rsearch(n->identifier); 
                 std::reverse(root_to_node.begin(), root_to_node.end());
@@ -1181,7 +1181,7 @@ Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::get_subtree (const Mutati
             }
             // Add to the parent identified
             else {
-                Node* new_node = subtree.create_node(n->identifier, subtree_parent->identifier);
+                Node* new_node = subtree.create_node(n->identifier, subtree_parent->identifier, -1.0, n->epps);
 
                 std::vector<Node*> par_to_node;
                 for (auto anc: tree.rsearch(n->identifier)) {

--- a/src/mutation_annotated_tree.hpp
+++ b/src/mutation_annotated_tree.hpp
@@ -116,9 +116,9 @@ namespace Mutation_Annotated_Tree {
             std::vector<Node*> get_leaves(std::string nid="");
             std::vector<std::string> get_leaves_ids(std::string nid="");
             size_t get_num_leaves(Node* node=NULL);
-            Node* create_node (std::string const& identifier, float branch_length = -1.0);
-            Node* create_node (std::string const& identifier, Node* par, float branch_length = -1.0);
-            Node* create_node (std::string const& identifier, std::string const& parent_id, float branch_length = -1.0);
+            Node* create_node (std::string const& identifier, float branch_length = -1.0, int epps = 0); 
+            Node* create_node (std::string const& identifier, Node* par, float branch_length = -1.0, int epps = 0);
+            Node* create_node (std::string const& identifier, std::string const& parent_id, float branch_length = -1.0, int epps = 0);
             Node* get_node (std::string identifier) const;
             bool is_ancestor (std::string anc_id, std::string nid) const;
             std::vector<Node*> rsearch (const std::string& nid) const;


### PR DESCRIPTION
This PR includes a total rework of how commands for matUtils are being handled to follow a new streamlined workflow. matUtils is now divided into three segments; annotate adds values to the protobuf, filter removes data from the protobuf, and convert produces non-protobuf files. A matUtils workflow will naturally call annotate, then filter, then convert to produce a dataset of interest.  The README has been updated accordingly.

This PR also includes updates to node creation methods and the matUtils annotate command to maintain metadata data values as the tree is recondensed and saved, as well as automatically recondensing the tree after annotation before storage. These should not interfere with the primary Usher package. 

It's notable that there is a significant bug with the Filter subcommand's "restrictSamples", where the tree is apparently unable to identify any samples included (making it nonfunctional as of this commit). This seems to be limited to this command as a direct issue, but may indicate something strange going on with the tree internal node identifiers. Or its possible that I've just missed something?