### PR TITLE
Command restructure, neighborhood size, and EPPs-based filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,11 @@ Mutation-annotated tree file generated using UShER.
 
 **-p**: Calculate and store total tree parsimony. 
 
-**-e**: Calculate and store equally parsimonious placements for all samples in the tree.
+**-e**: Calculate and store equally parsimonious placements and placement neighborhood sizes for all samples in the tree.
+
+**-l**: Provide a path to a file assigning lineages to samples to locate and annotate clade root nodes.
+
+**-f**: Set the minimum allele frequency in samples to find the best clade root node. Used only with -l.
 
 **-h**: Print help messages
 

--- a/parsimony.proto
+++ b/parsimony.proto
@@ -21,6 +21,7 @@ message condensed_node {
 message node_metadata {
     int32 sample_epps = 1;
     string clade = 2;
+    int32 neighborhood_size = 3;
 }
 
 message data {

--- a/src/matUtils.cpp
+++ b/src/matUtils.cpp
@@ -369,9 +369,6 @@ size_t get_neighborhood_size(std::vector<MAT::Node*> nodes, MAT::Tree* T) {
     for (size_t s=0; s<common_nodes.size(); s++) {
         //get the set of distances between each placement to this common ancestor with the path vectors
         std::vector<float> distances = get_all_distances(common_nodes[s], parentvecs);
-        for (auto i = distances.begin(); i != distances.end(); ++i) {
-            std::cerr << *i << ',';
-        }
         //now find the biggest sum of shared values for this specific common node
         float widest = 0.0;
         for (size_t i=0; i<distances.size(); i++) {

--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -465,6 +465,7 @@ Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::load_mutation_annotated_t
                    auto metaobj = data.metadata(idx); 
                    node->epps = metaobj.sample_epps();
                    node->clade = metaobj.clade();
+                   node->neighborhood_size = metaobj.neighborhood_size();
                } else {
                    node->epps = 0; 
                    node->clade = ""; 
@@ -524,7 +525,7 @@ void Mutation_Annotated_Tree::save_mutation_annotated_tree (Mutation_Annotated_T
         auto meta = data.add_metadata();
         meta->set_sample_epps(dfs[idx]->epps);
         meta->set_clade(dfs[idx]->clade);
-
+        meta->set_neighborhood_size(dfs[idx]->neighborhood_size);
         auto mutation_list = data.add_node_mutations();
         for (auto m: dfs[idx]->mutations) {
             auto mut = mutation_list->add_mutation();

--- a/src/mutation_annotated_tree.hpp
+++ b/src/mutation_annotated_tree.hpp
@@ -78,7 +78,8 @@ namespace Mutation_Annotated_Tree {
             float branch_length;
             std::string identifier;
             std::string clade;
-            int epps = 0; //JDM-add a new variable attribute, integer, its the epps count. Default 0? 
+            int epps = 0;
+            size_t neighborhood_size = 0;
             Node* parent;
             std::vector<Node*> children;
             std::vector<Mutation> mutations;


### PR DESCRIPTION
This PR includes three major changes. The first is to the command structure, incorporating the new lineage-assignment function under the annotate heading, including an updated help message as well. The second is debugging and implementing neighborhood size calculation, which is a quality metric being the longest direct traversable path between two equally parsimonious placements within a set of at least two equally parsimonious placements for a given sample (smaller is better). Generally, a sample with high EPPs where all placements are nearby on the tree will have a low neighborhood score, while a sample with two EPPs on very different parts of the tree will have a high neighborhood score. Third, I've implemented a simple EPPs-based filtering loop under matUtils filter, which can be used to create a MAT representing high-confidence placements only. 

My only major concern at this time is that it takes about a tenth of a second to annotate each sample in the tree with metadata, and as the tree grows to hundreds of thousands of samples, this takes an increasing number of hours. It may be worth revisiting this and parallelizing the outer loop instead of the inner loop to see if that saves on runtime. 