### PR TITLE
Comment reformat and matUtils README drafting

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,57 +264,7 @@ For the example above, a new VCF *test/test_merged.vcf* is generated (identical 
 
 ## matUtils
 
-We are now providing a toolkit, `matUtils`, which can perform a number of tasks related to manipulating and querying the UShER's mutation-annotated tree, such as the generation of the corresponding Newick tree or parsimony-resolved VCF file, masking out mutations specific to certain samples, calculating the number of equally parsimonious placements for all samples currently included in the mutation-annotated tree as well as the total parsimony score of the tree (see usage options below).
-
-### Input
-
-Mutation-annotated tree file generated using UShER.
-
-### Options
-
-#### Annotate
-
-**-i**: Input mutation-annotated tree file (REQUIRED)
-
-**-o**: Output mutation-annotated tree file (REQUIRED)
-
-**-l**: Provide a path to a file assigning lineages to samples to locate and annotate clade root nodes (REQUIRED)
-
-**-f**: Set the minimum allele frequency in samples to find the best clade root node (default = 0.9)
-
-**-h**: Print help messages
-
-#### Filter
-
-**-i**: Input mutation-annotated tree file (REQUIRED) 
-
-**-o**: Output mutation-annotated tree file (REQUIRED)
-
-**-s**: Use to mask specific samples from the tree. 
-
-**-h**: Print help messages
-
-#### Convert
-
-**-i**: Input mutation-annotated tree file (REQUIRED) 
-
-**-v**: Output VCF file 
-
-**-t**: Output Newick tree file
-
-**-n**: Do not include sample genotype columns in VCF output. Used only with -v
-
-**-h**: Print help messages
-
-### Usage example
-
-```
-./build/matUtils convert -i global_assignments.pb -v global_assignments.vcf -t global_assignments.nh
-```
-
-### Output
-
-The above example command generates a VCF file named `global_assignments.vcf` and the output tree named `global_assignments.nh`.
+We are now providing a toolkit, `matUtils`, which can perform a number of tasks related to manipulating and querying the UShER's mutation-annotated tree, such as the generation of the corresponding Newick tree or parsimony-resolved VCF file, masking out mutations, or calculating the number of equally parsimonious placements for a specific set of samples. Full documentation for this toolkit can be found under [src/matUtils](https://github.com/yatisht/usher/blob/master/src/matUtils/README.md).
 
 ## Acknowledgement
 

--- a/src/matUtils/README.md
+++ b/src/matUtils/README.md
@@ -1,1 +1,78 @@
 # matUtils
+matUtils is a toolkit for working with mutation annotated tree protobuf files, targeted towards filtering and extraction of desired information. It is divided into a number of subcommands. Each subcommand is called individually and has its own parameters and options; for example "matUtils annotate --help" yields the help message for the annotate subcommand of the matUtils toolkit.
+
+### Common Options
+
+**-i**: Input mutation-annotated tree file (REQUIRED)
+
+**-T**: Number of threads to use for multithreaded procedures. Default is all available
+
+**-h**: Print help messages
+
+## Annotate
+
+The annotate command takes a MAT protobuf file and a two-column tab-separated text file indicating sample names and lineage assignments. The software will automatically identify the best clade root for that lineage and save the assignment to each sample indicated, returning a new protobuf with these values stored.
+
+### Specific Options
+
+**-o**: Output mutation-annotated tree file (REQUIRED)
+
+**-l**: Provide a path to a file assigning lineages to samples to locate and annotate clade root nodes (REQUIRED)
+
+**-f**: Set the minimum allele frequency in samples to find the best clade root node (default = 0.9)
+
+## Convert 
+
+The convert subcommand yields non-protobuf format files representing the tree. This can be a newick format file and/or a VCF representing each sample's variations from the reference. 
+
+### Specific Options
+
+**-v**: Output VCF file 
+
+**-t**: Output Newick tree file
+
+**-n**: Do not include sample genotype columns in VCF output. Used only with -v
+
+## Filter
+
+The filter subcommand restricts indicated sample names and returns a masked protobuf.
+
+### Specific Options
+
+**-o**: Output mutation-annotated tree file (REQUIRED)
+
+**-s**: Use to mask specific samples from the tree. 
+
+## Describe
+
+Describe fetches the path of mutations associated with each indicated sample's placement on the tree and prints the results.
+
+### Specific Options
+ 
+**-m**: File containing sample names for which mutation paths should be displayed (REQUIRED)
+
+## Prune
+
+Prune removes an indicated set of samples from the input MAT, returning a smaller MAT.
+
+### Specific Options
+
+**-o**: Output mutation annotated tree [REQUIRED]
+
+**-p**: File containing names of samples to be pruned from the input MAT.
+
+**-P**: File containing names of samples to retain in the input MAT, pruning all others.
+
+## Uncertainty
+
+The uncertainty command calculates placement quality metrics for a set of samples or the whole tree and returns these values in the indicated format.
+
+### Specific Options
+
+**-s**: File containing names of samples to calculate metrics for.
+
+**-g**: Calculate and print the total tree parsimony score. 
+
+**-e**: Name for an output Nextstrain Auspice-compatible .tsv file of the number of equally parsimonious placement values for each indicated sample- smaller is better, best is 1 (requires -s).
+
+**-n**: Name for an output Nextstrain Auspice-compatible .tsv file of neighborhood size scores for the equally parsimonious placements for each indicated sample- smaller is better, best is 0 (requires -s).


### PR DESCRIPTION
I've written a first draft matUtils README. The formatting is basic and could be improved- looking for feedback there. Alongside this, I've updated the main README to only briefly describe matUtils and link to the matUtils-specific README (well, specifically to the matUtils README on the main Usher repository master branch). 

I've also cleaned up some of my code comments along the lines of your comments on my last PR, breaking up long lines and moving comments to their own lines. I've also added some paragraph comments describing the method and purpose of each of the uncertainty metrics we currently support in matUtils uncertainty. 