### PR TITLE
Quick Documentation Fixes

### DIFF
--- a/src/matUtils/README.md
+++ b/src/matUtils/README.md
@@ -33,9 +33,9 @@ The convert subcommand yields non-protobuf format files representing the tree. T
 
 **-n**: Do not include sample genotype columns in VCF output. Used only with -v
 
-## Filter
+## Mask
 
-The filter subcommand restricts indicated sample names and returns a masked protobuf.
+The mask subcommand restricts indicated sample names and returns a masked protobuf.
 
 ### Specific Options
 
@@ -51,9 +51,9 @@ Describe fetches the path of mutations associated with each indicated sample's p
  
 **-m**: File containing sample names for which mutation paths should be displayed (REQUIRED)
 
-## Prune
+## Filter
 
-Prune removes an indicated set of samples from the input MAT, returning a smaller MAT.
+Filter removes an indicated set of samples from the input MAT, returning a smaller MAT.
 
 ### Specific Options
 
@@ -76,3 +76,15 @@ The uncertainty command calculates placement quality metrics for a set of sample
 **-e**: Name for an output Nextstrain Auspice-compatible .tsv file of the number of equally parsimonious placement values for each indicated sample- smaller is better, best is 1 (requires -s).
 
 **-n**: Name for an output Nextstrain Auspice-compatible .tsv file of neighborhood size scores for the equally parsimonious placements for each indicated sample- smaller is better, best is 0 (requires -s).
+
+## Summary
+
+This command gets basic statistics about the input MAT.
+
+### Specific Options
+
+**-s**: Write a tsv listing all samples in the tree and their parsimony scores (terminal branch length).
+
+**-c**: Write a tsv listing all clades in the tree and their occurrence over nodes in the tree.
+
+**-m**: Write a tsv listing all mutations in the tree and their occurrence count.

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -4,7 +4,6 @@
 #include "filter.hpp"
 #include "describe.hpp"
 #include "uncertainty.hpp"
-#include "select.hpp"
 #include "summary.hpp"
 
 Timer timer; 

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -5,6 +5,7 @@
 #include "describe.hpp"
 #include "uncertainty.hpp"
 #include "select.hpp"
+#include "summary.hpp"
 
 Timer timer; 
 
@@ -34,9 +35,11 @@ int main (int argc, char** argv) {
             describe_main(parsed); 
         } else if (cmd == "uncertainty") {
             uncertainty_main(parsed);
+        } else if (cmd == "summary") {
+            summary_main(parsed);
         } else if (cmd == "help" || cmd == "--help" || cmd == "-h") { 
             // TODO: improve this message
-            fprintf(stderr, "matUtils has several major subcommands: annotate, mask, convert, prune, uncertainty, and describe.\nIndividual command options can be accessed with matUtils command --help, e.g. matUtils annotate --help will show annotation-specific help messages.");
+            fprintf(stderr, "matUtils has several major subcommands: annotate, mask, convert, filter, uncertainty, summary, and describe.\nIndividual command options can be accessed with matUtils command --help, e.g. matUtils annotate --help will show annotation-specific help messages.");
             exit(0);
         } else {
             fprintf(stderr, "Invalid command. Please choose from annotate, mask, convert, filter, describe, uncertainty, summary, or help and try again.\n"););

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -41,7 +41,7 @@ int main (int argc, char** argv) {
             fprintf(stderr, "matUtils has several major subcommands: annotate, mask, convert, filter, uncertainty, summary, and describe.\nIndividual command options can be accessed with matUtils command --help, e.g. matUtils annotate --help will show annotation-specific help messages.");
             exit(0);
         } else {
-            fprintf(stderr, "Invalid command. Please choose from annotate, mask, convert, filter, describe, uncertainty, summary, or help and try again.\n"););
+            fprintf(stderr, "Invalid command. Please choose from annotate, mask, convert, filter, describe, uncertainty, summary, or help and try again.\n");
             exit(1);
         }
     } catch (...) { //not sure this is the best way to catch it when matUtils is called with no positional arguments.

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -4,7 +4,7 @@
 #include "filter.hpp"
 #include "describe.hpp"
 #include "uncertainty.hpp"
-#include "summary.hpp"
+#include "select.hpp"
 
 Timer timer; 
 
@@ -22,7 +22,6 @@ int main (int argc, char** argv) {
 
         po::store(parsed, vm);
         std::string cmd = vm["command"].as<std::string>();
-        //starting to think this should be a switch?...
         if (cmd == "annotate"){
             annotate_main(parsed);
         } else if (cmd == "convert"){
@@ -35,8 +34,6 @@ int main (int argc, char** argv) {
             describe_main(parsed); 
         } else if (cmd == "uncertainty") {
             uncertainty_main(parsed);
-        } else if (cmd == "summary") {
-            summary_main(parsed);
         } else if (cmd == "help" || cmd == "--help" || cmd == "-h") { 
             // TODO: improve this message
             fprintf(stderr, "matUtils has several major subcommands: annotate, mask, convert, prune, uncertainty, and describe.\nIndividual command options can be accessed with matUtils command --help, e.g. matUtils annotate --help will show annotation-specific help messages.");

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -39,11 +39,11 @@ int main (int argc, char** argv) {
             fprintf(stderr, "matUtils has several major subcommands: annotate, mask, convert, prune, uncertainty, and describe.\nIndividual command options can be accessed with matUtils command --help, e.g. matUtils annotate --help will show annotation-specific help messages.");
             exit(0);
         } else {
-            fprintf(stderr, "Invalid command. Please choose from annotate, mask, convert, prune, describe, uncertainty, or help and try again.\n");
+            fprintf(stderr, "Invalid command. Please choose from annotate, mask, convert, filter, describe, uncertainty, summary, or help and try again.\n"););
             exit(1);
         }
     } catch (...) { //not sure this is the best way to catch it when matUtils is called with no positional arguments.
-        fprintf(stderr, "No command selected. Please choose from annotate, mask, convert, prune, describe, uncertainty, or help and try again.\n");
+        fprintf(stderr, "No command selected. Please choose from annotate, mask, convert, filter, describe, uncertainty, summary, or help and try again.\n");
         exit(0);
     }
 


### PR DESCRIPTION
Sorry for not staying on the ball with this in the last batch of changes. The help strings and README should reflect the most recent use of command names (old prune = new filter), plus the summary module should actually be an option now (somehow the summary src got committed but the actual parsing of a summary command did not). 

Pretty much everything in this PR except for the summary command parsing will be overwritten with the shift to using extract for most functionality this week, but this will hopefully make things usable in the next couple days.