### PR TITLE
A small, warning-and-text based PR

### DIFF
--- a/src/matUtils/filter.cpp
+++ b/src/matUtils/filter.cpp
@@ -58,7 +58,6 @@ MAT::Tree get_sample_prune (const MAT::Tree& T, std::vector<std::string> sample_
     //which is important when we're looking at large sample inputs
     //so convert the sample names vector to an unordered set
     std::unordered_set<std::string> setnames(sample_names.begin(),sample_names.end());
-
     auto subtree = MAT::get_tree_copy(T);
     auto dfs = T.depth_first_expansion();
     for (auto s: dfs) {
@@ -66,7 +65,10 @@ MAT::Tree get_sample_prune (const MAT::Tree& T, std::vector<std::string> sample_
         if (s->is_leaf()) {
             //if the node is NOT in the set, remove it
             if (setnames.find(s->identifier) == setnames.end()) {
-                subtree.remove_node(s->identifier, true);
+                //BUG NOTE: I'm setting the move to false here to patch over this problem
+                //if its set to true, then sometimes it will fail to save properly- overwriting root?
+                //leave this as not using the move for now, but needs to be revisited
+                subtree.remove_node(s->identifier, false);
             }
         }
     }    

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -313,8 +313,15 @@ int main (int argc, char** argv) {
         po::store(parsed, vm);
         cmd = vm["command"].as<std::string>();
     } catch (...) { //not sure this is the best way to catch it when matUtils is called with no positional arguments.
-        fprintf(stderr, "No command selected. Please choose from annotate, mask, extract, summary, uncertainty, or help and try again.\n");
-        exit(0);
+        fprintf(stderr, "No command selected. Help follows:\n"
+        "matUtils has several valid subcommands: \n\n"
+        "extract: subsets the input MAT on various conditions and converts to other tree formats\n\n"
+        "summary: calculates basic statistics and counts members in the input MAT\n\n"
+        "annotate: assigns clade identities to nodes, directly or by inference\n\n"
+        "uncertainty: calculates sample placement uncertainty metrics and writes the results to tsv\n\n"
+        "mask: masks the input samples\n\n"
+        "Individual command options can be accessed with matUtils command --help, e.g. matUtils annotate --help will show annotation-specific help messages.\n");
+        exit(1);
     }
     if (cmd == "extract") {
         extract_main(parsed);

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -335,7 +335,6 @@ void extract_main (po::parsed_options parsed) {
         if (collapse_tree) {
             subtree.collapse_tree();
         }
-        fprintf(stderr, "DEBUG: Successfully condensed\n");
         MAT::save_mutation_annotated_tree(subtree, output_mat_filename);
         fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
         wrote_output = true;

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -313,6 +313,7 @@ int main (int argc, char** argv) {
         po::store(parsed, vm);
         cmd = vm["command"].as<std::string>();
     } catch (...) { //not sure this is the best way to catch it when matUtils is called with no positional arguments.
+        //TODO: I probably don't need to define this help string so many times.
         fprintf(stderr, "No command selected. Help follows:\n"
         "matUtils has several valid subcommands: \n\n"
         "extract: subsets the input MAT on various conditions and converts to other tree formats\n\n"

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -278,12 +278,12 @@ void extract_main (po::parsed_options parsed) {
         fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
     }
     //last step is to convert the subtree to other file formats
-    if (vcf_filename != "./") {
+    if (vcf_filename != dir_prefix) {
         fprintf(stderr, "Generating VCF of final tree\n");
         make_vcf(subtree, vcf_filename, no_genotypes);
         wrote_output = true;
     }
-    if (tree_filename != "./") {
+    if (tree_filename != dir_prefix) {
         fprintf(stderr, "Generating Newick file of final tree\n");
         FILE *tree_file = fopen(tree_filename.c_str(), "w");
         fprintf(tree_file, "%s\n",
@@ -292,7 +292,7 @@ void extract_main (po::parsed_options parsed) {
         wrote_output = true;
     }
     //and save a MAT if that was set
-    if (output_mat_filename != "./") {
+    if (output_mat_filename != dir_prefix) {
         fprintf(stderr, "Saving output MAT file %s.\n", output_mat_filename.c_str()); 
         subtree.condense_leaves();
         if (collapse_tree) {

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -333,7 +333,8 @@ int main (int argc, char** argv) {
     } catch (...) { //not sure this is the best way to catch it when matUtils is called with no positional arguments.
         fprintf(stderr, "No command selected. Help follows:\n\n");
         fprintf(stderr, helpstr.c_str());
-        exit(1);
+        //0 when no command is selected because that's what passes tests.
+        exit(0);
     }
     if (cmd == "extract") {
         extract_main(parsed);

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -151,7 +151,6 @@ void extract_main (po::parsed_options parsed) {
         //proceed to the normal intersection code
         if (samples.size() == 0) {
             samples = samples_in_clade;
-            //fprintf(stderr, "DEBUG: %ld samples in vector after clade choice\n", samples.size());
         } else {
             samples = sample_intersect(samples, samples_in_clade);
         }
@@ -301,7 +300,6 @@ void extract_main (po::parsed_options parsed) {
                     }
                 }
             }
-            //fprintf(stderr, "DEBUG: %ld clades detected", cladenames.size());
             std::ofstream outfile (clade_path_filename);
             //TODO: maybe better to update clade_paths to take an "all current clades" option.
             //should be more computationally efficient at least.

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -118,7 +118,7 @@ void extract_main (po::parsed_options parsed) {
     //explicit setting goes first, then clade, then mutation, then epps- in order of increasing runtime for checking sample membership
     //to maximize efficiency (no need to calculate epps for a sample you're going to throw out in the next statement)
     timer.Start();
-    fprintf(stderr, "Parsing and applying sample selection arguments\n");
+    fprintf(stderr, "Checking for and applying sample selection arguments\n");
     //TODO: sample select code could take a previous list of samples to check in some cases like what EPPs does
     //which could save on runtime compared to getting instances across the whole tree and intersecting
     //though the current setup would enable more complex things, like saying this OR this in arguments, it's less efficient
@@ -303,7 +303,7 @@ void extract_main (po::parsed_options parsed) {
         wrote_output = true;
     }
     if (!wrote_output) {
-        fprintf(stderr, "WARNING: No output files requested!");
+        fprintf(stderr, "WARNING: No output files requested!\n");
     }
 }
 
@@ -319,19 +319,19 @@ int main (int argc, char** argv) {
     po::variables_map vm;
     po::parsed_options parsed = po::command_line_parser(argc, argv).options(global).positional(pos).allow_unregistered().run();
     //this help string shows up over and over, lets just define it once
-    std::string helpstr = "No command selected. Help follows:\n\n"
-        "matUtils has several valid subcommands: \n\n"
+    std::string helpstr = "matUtils has several valid subcommands: \n\n"
         "extract: subsets the input MAT on various conditions and/or converts to other formats (MAT, newick, VCF, etc)\n\n"
         "summary: calculates basic statistics and counts members in the input MAT\n\n"
         "annotate: assigns clade identities to nodes, directly or by inference\n\n"
         "uncertainty: calculates sample placement uncertainty metrics and writes the results to tsv\n\n"
         "mask: masks the input samples\n\n"
-        "Individual command options can be accessed with matUtils command --help, e.g. matUtils annotate --help will show annotation-specific help messages.\n";
+        "Individual command options can be accessed with matUtils command --help, e.g. matUtils annotate --help will show annotation-specific help messages.\n\n";
     
     try {
         po::store(parsed, vm);
         cmd = vm["command"].as<std::string>();
     } catch (...) { //not sure this is the best way to catch it when matUtils is called with no positional arguments.
+        fprintf(stderr, "No command selected. Help follows:\n\n");
         fprintf(stderr, helpstr.c_str());
         exit(1);
     }
@@ -349,6 +349,7 @@ int main (int argc, char** argv) {
         fprintf(stderr, helpstr.c_str());
         exit(0);
     } else {
+        fprintf(stderr, "Invalid command. Help follows:\n\n");
         fprintf(stderr, helpstr.c_str());
         exit(1);
     }

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -207,7 +207,6 @@ void extract_main (po::parsed_options parsed) {
         //this specific sample parser only calculates for values present in samples argument
         //so it doesn't need any intersection code
         //if no samples are indicated, you get it for the whole tree. This can take several hours.
-        samples = get_samples_epps(T, max_epps, samples);
         //check to make sure we haven't emptied our sample set; if we have, throw an error
         if (samples.size() == 0) {
             fprintf(stderr, "ERROR: No samples fulfill selected criteria. Change arguments and try again\n");
@@ -263,7 +262,7 @@ void extract_main (po::parsed_options parsed) {
     //its basically just that the selection of two samples is very dependent on the other samples which were valid
     //add a valid samples vector argument to the clade representatives function and check membership before selection, maybe
     if (get_representative) {
-        fprintf(stderr, "Filtering again to a clade representative tree...\n");
+        //fprintf(stderr, "Filtering again to a clade representative tree...\n");
         auto rep_samples = get_clade_representatives(subtree);
         //run filter master again
         subtree = filter_master(subtree, rep_samples, false);
@@ -336,6 +335,7 @@ void extract_main (po::parsed_options parsed) {
         if (collapse_tree) {
             subtree.collapse_tree();
         }
+        fprintf(stderr, "DEBUG: Successfully condensed\n");
         MAT::save_mutation_annotated_tree(subtree, output_mat_filename);
         fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
         wrote_output = true;

--- a/src/matUtils/select.cpp
+++ b/src/matUtils/select.cpp
@@ -83,9 +83,11 @@ std::vector<std::string> get_mutation_samples (MAT::Tree T, std::string mutation
             for (auto anc_node: path) {
                 if (!assigned) {
                     for (auto m: anc_node->mutations) {
-                        good_samples.push_back(node->identifier);
-                        assigned = true;
-                        break;                
+                        if (m.get_string() == mutation_id) {
+                            good_samples.push_back(node->identifier);
+                            assigned = true;
+                            break;     
+                        }
                     }
                 } else {
                     break;
@@ -93,6 +95,7 @@ std::vector<std::string> get_mutation_samples (MAT::Tree T, std::string mutation
             }
         }
     }
+    // fprintf(stderr, "# of good samples %ld\n", good_samples.size());
     return good_samples;
 }
 

--- a/src/matUtils/summary.cpp
+++ b/src/matUtils/summary.cpp
@@ -179,8 +179,8 @@ void summary_main(po::parsed_options parsed) {
                 samplecount++;
             }
         }
-        fprintf(stderr, "Total Nodes in Tree: %d\n", nodecount);
-        fprintf(stderr, "Total Samples in Tree: %d\n", samplecount);
+        fprintf(stdout, "Total Nodes in Tree: %d\n", nodecount);
+        fprintf(stdout, "Total Samples in Tree: %d\n", samplecount);
         fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
     }
 }

--- a/src/matUtils/summary.cpp
+++ b/src/matUtils/summary.cpp
@@ -66,7 +66,7 @@ void write_clade_table(MAT::Tree& T, std::string filename) {
     cladefile << "clade\tcount\n";
     //clades will be a map object.
     std::map<std::string, size_t> cladecounts;
-    
+    std::cerr << T.root->clade_annotations[0] << T.root->clade_annotations[1] << "\n";
     auto dfs = T.depth_first_expansion();
     for (auto s: dfs) {
         std::vector<std::string> canns = s->clade_annotations;
@@ -76,19 +76,19 @@ void write_clade_table(MAT::Tree& T, std::string filename) {
                 //skip entries which are annotated with 1 clade but that clade is empty
                 //but don't skip entries which are annotated with 1 clade and its not empty
                 //get the set of samples descended from this clade root
-                std::vector<std::string> sids = T.get_leaves_ids(s->identifier);
                 for (auto c: canns) {
-                    //the emptry string is a default clade identifier
+                    //the empty string is a default clade identifier
                     //make sure not to include it.
-                    if (cladecounts.find(c) != cladecounts.end() && c != "") {
-                        cladecounts[c] = cladecounts[c] + sids.size();
-                    } else if (c != "") {
+                    //the first time you encounter it should be the root of the clade
+                    //then if you see if after that you can ignore it. probably?
+                    if (cladecounts.find(c) == cladecounts.end() && c != "") {
+                        std::vector<std::string> sids = T.get_leaves_ids(s->identifier);
                         cladecounts[c] = sids.size();
                     }
                 }        
             }
         }
-    }   
+    }
     //write the contents of map to the file.
     for (auto const &clade : cladecounts) {
         cladefile << clade.first << "\t" << clade.second << "\n";

--- a/src/matUtils/uncertainty.cpp
+++ b/src/matUtils/uncertainty.cpp
@@ -433,9 +433,10 @@ void uncertainty_main(po::parsed_options parsed) {
         findEPPs_wrapper(T, sample_file, fepps, fneigh);
     }
     if (get_parsimony){
-        fprintf(stderr, "Total Tree Parsimony %ld\n", T.get_parsimony_score());
+        fprintf(stdout, "Total Tree Parsimony %ld\n", T.get_parsimony_score());
     }
     if (fepps != "" && fneigh != "" && !get_parsimony) {
         fprintf(stderr, "No actions chosen. Review arguments\n");
+        exit(1);
     }
 }

--- a/src/matUtils/uncertainty.cpp
+++ b/src/matUtils/uncertainty.cpp
@@ -436,6 +436,6 @@ void uncertainty_main(po::parsed_options parsed) {
         fprintf(stderr, "Total Tree Parsimony %ld\n", T.get_parsimony_score());
     }
     if (fepps != "" && fneigh != "" && !get_parsimony) {
-        fprintf(stderr, "No actions chosen. Review arguments\n")
+        fprintf(stderr, "No actions chosen. Review arguments\n");
     }
 }

--- a/src/matUtils/uncertainty.cpp
+++ b/src/matUtils/uncertainty.cpp
@@ -313,7 +313,10 @@ void findEPPs_wrapper (MAT::Tree Tobj, std::string sample_file, std::string fepp
             samples.emplace_back(sample);
         }
         fprintf(stderr, "Processing %ld samples\n", samples.size()); 
-    } 
+    } else {
+        fprintf(stderr, "WARNING: No sample file indicated; calculating for full tree\n");
+        samples = T->get_leaves_ids();
+    }
     //this loop is not a parallel for because its going to contain a parallel for.
     //this specific function would probably be better optimized if the outer was parallelized and the inner was not
     //but having the inner loop parallelized lets me use parallelization when calculating EPPs for very few or single samples in the future
@@ -430,6 +433,9 @@ void uncertainty_main(po::parsed_options parsed) {
         findEPPs_wrapper(T, sample_file, fepps, fneigh);
     }
     if (get_parsimony){
-        fprintf(stderr, "Total Tree Parsimony %ld", T.get_parsimony_score());
+        fprintf(stderr, "Total Tree Parsimony %ld\n", T.get_parsimony_score());
+    }
+    if (fepps != "" && fneigh != "" && !get_parsimony) {
+        fprintf(stderr, "No actions chosen. Review arguments\n")
     }
 }

--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -1007,7 +1007,6 @@ void Mutation_Annotated_Tree::Tree::condense_leaves(std::vector<std::string> mis
                 polytomy_nodes.push_back(l2);
             }
         }
-
         if (polytomy_nodes.size() > 1) {
             std::string new_node_name = "node_" + std::to_string(1+condensed_nodes.size()) + "_condensed_" + std::to_string(polytomy_nodes.size()) + "_leaves";
             
@@ -1208,7 +1207,12 @@ Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::get_subtree (const Mutati
             if (subtree_parent == NULL) {
                 // for root node, need to size the annotations vector
                 Node* new_node = subtree.create_node(n->identifier, -1.0, num_annotations);
-                
+                // need to assign any clade annotations which would belong to that root as well
+                for (size_t k = 0; k < num_annotations; k++) {
+                    if (n->clade_annotations[k] != "") {
+                        new_node->clade_annotations[k] = n->clade_annotations[k];
+                    }
+                }
                 std::vector<Node*> root_to_node = tree.rsearch(n->identifier, true); 
                 std::reverse(root_to_node.begin(), root_to_node.end());
                 root_to_node.emplace_back(n);


### PR DESCRIPTION
To follow up with the biggest PR, let's do the smallest. This includes a change to defining the help string just once and referring to it as necessary, the addition of a bool in extract for checking whether the user actually specified any output and printing a warning if not, and an update to the uncertainty command to have a default behavior of checking all samples in the tree as intended.