### PR TITLE
Bugfixes and Node Mutation printing

### DIFF
--- a/src/matUtils/README.md
+++ b/src/matUtils/README.md
@@ -15,9 +15,9 @@ This command selects subtrees from the MAT based on clade identification, sample
 
 **-s**: Select samples to extract by explicitly naming them, one per line in a text file.
 
-**-c**: Select samples to extract by membership in the indicated clade.
+**-c**: Select samples by membership in at least one of the indicated clade(s), comma delimited.
 
-**-m**: Select samples to extract by whether they contain the indicated mutation.
+**-m**: Select samples by whether they contain any of the indicated mutation(s), comma delimited.
 
 **-e**: Select samples to extract by whether they have less than the indicated number of equally parsimonious placements. Note: adds significantly to runtime with large sample selections.
 

--- a/src/matUtils/README.md
+++ b/src/matUtils/README.md
@@ -33,6 +33,8 @@ This command selects subtrees from the MAT based on clade identification, sample
 
 **-C**: Write the path of mutations defining each clade in the subtree after sample extraction to a file.
 
+**-A**: Write the path of mutations defining each node in the selected tree to the target file.
+
 **-v**: Convert the subtree to a VCF and write it to the indicated file.
 
 **-n**: Do not include sample genotype columns in the VCF output. Used only with -v

--- a/src/matUtils/README.md
+++ b/src/matUtils/README.md
@@ -33,7 +33,7 @@ This command selects subtrees from the MAT based on clade identification, sample
 
 **-C**: Write the path of mutations defining each clade in the subtree after sample extraction to a file.
 
-**-A**: Write the path of mutations defining each node in the selected tree to the target file.
+**-A**: Write mutations assigned to each node in the selected tree to the target file.
 
 **-v**: Convert the subtree to a VCF and write it to the indicated file.
 

--- a/src/matUtils/describe.cpp
+++ b/src/matUtils/describe.cpp
@@ -72,3 +72,19 @@ std::vector<std::string> clade_paths(MAT::Tree T, std::vector<std::string> clade
     }
     return clpaths;
 }
+
+std::vector<std::string> all_nodes_paths(MAT::Tree T) {
+    std::vector<std::string> dfs_strings;
+    auto dfs = T.depth_first_expansion();
+    for (auto n: dfs) {
+        std::string node_path = n->identifier + "\t";
+        for (size_t i=0; i<n->mutations.size(); i++) {
+            node_path += n->mutations[i].get_string();
+            if (i+1 < n->mutations.size()) {
+                node_path += ",";
+            }
+        }
+        dfs_strings.push_back(node_path);
+    }
+    return dfs_strings;
+}

--- a/src/matUtils/describe.cpp
+++ b/src/matUtils/describe.cpp
@@ -29,7 +29,7 @@ std::vector<std::string> clade_paths(MAT::Tree T, std::vector<std::string> clade
     //get the set of clade path strings for printing
     //similar to the above, construct a series of strings to be printed or redirected later on
     std::vector<std::string> clpaths;
-    clpaths.push_back("clade\troot_id\tfrom_tree_root");
+    clpaths.push_back("clade\troot_id\tfrom_tree_root\n");
     //do a breadth-first search
     //the first time a clade that is in clades is encountered, that's the root;
     //get the path of mutations to that root (rsearch), save the unique mutations + that path

--- a/src/matUtils/describe.cpp
+++ b/src/matUtils/describe.cpp
@@ -2,8 +2,9 @@
 
 std::vector<std::string> mutation_paths(const MAT::Tree& T, std::vector<std::string> samples) {
     std::vector<std::string> mpaths;
+    mpaths.push_back("sample_id\tpath_from_root");
     for (auto sample: samples) {
-        std::string cpath = sample + ": ";
+        std::string cpath = sample + "\t";
         auto root_to_sample = T.rsearch(sample, true);
         std::reverse(root_to_sample.begin(), root_to_sample.end());
         for (auto n: root_to_sample) {

--- a/src/matUtils/describe.cpp
+++ b/src/matUtils/describe.cpp
@@ -35,13 +35,13 @@ std::vector<std::string> clade_paths(MAT::Tree T, std::vector<std::string> clade
     //unique mutations being ones that occurred in the clade root, and the path being all mutations from that root back to the tree root
     //then continue. if a clade has already been encountered in the breadth first, its
     //not clade root, and should be skipped.
-    std::unordered_set<std::string> clades_seen;
+    std::set<std::string> clades_seen;
 
     auto dfs = T.breadth_first_expansion();
     for (auto n: dfs) {
-        std::string curpath;
         for (auto ann: n->clade_annotations) {
             if (ann != "") {
+                std::string curpath;
                 //if its one of our target clades and it hasn't been seen...
                 if (std::find(clades.begin(), clades.end(), ann) != clades.end() && clades_seen.find(ann) == clades_seen.end()) {
                     //record the name of the clade

--- a/src/matUtils/describe.hpp
+++ b/src/matUtils/describe.hpp
@@ -2,3 +2,4 @@
 
 std::vector<std::string> mutation_paths(const MAT::Tree& T, std::vector<std::string> samples);
 std::vector<std::string> clade_paths(MAT::Tree T, std::vector<std::string> clades);
+std::vector<std::string> all_nodes_paths(MAT::Tree T);

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -24,9 +24,9 @@ po::variables_map parse_extract_command(po::parsed_options parsed) {
         ("samples,s", po::value<std::string>()->default_value(""),
         "Select samples by explicitly naming them. One per line")
         ("clade,c", po::value<std::string>()->default_value(""),
-        "Select samples by membership in the indicated clade(s), comma delimited.")
+        "Select samples by membership in at least one of the indicated clade(s), comma delimited.")
         ("mutation,m", po::value<std::string>()->default_value(""),
-        "Select samples by whether they contain the indicated mutation(s), comma delimited.")
+        "Select samples by whether they contain any of the indicated mutation(s), comma delimited.")
         ("max-epps,e", po::value<size_t>()->default_value(0),
         "Select samples by whether they have less than the maximum indicated number of equally parsimonious placements. Note: calculation adds significantly to runtime.")
         ("max-parsimony,a", po::value<int>()->default_value(-1),
@@ -235,6 +235,7 @@ void extract_main (po::parsed_options parsed) {
     //the final step of selection is to invert the set if prune is set
     //this is done by getting all sample names which are not in the samples vector.
     if (prune_samples) {
+        fprintf(stderr, "Sample pruning requested...\n");
         std::vector<std::string> nsamples;
         for (auto s: T.get_leaves_ids()) {
             //for every sample in the tree, if that sample is NOT in the selected set, save it
@@ -384,7 +385,7 @@ int main (int argc, char** argv) {
         cmd = vm["command"].as<std::string>();
     } catch (...) { //not sure this is the best way to catch it when matUtils is called with no positional arguments.
         fprintf(stderr, "No command selected. Help follows:\n\n");
-        fprintf(stderr, helpstr.c_str());
+        fprintf(stderr, "%s", helpstr.c_str());
         //0 when no command is selected because that's what passes tests.
         exit(0);
     }
@@ -399,11 +400,11 @@ int main (int argc, char** argv) {
     } else if (cmd == "summary") {
         summary_main(parsed);
     } else if (cmd == "help") { 
-        fprintf(stderr, helpstr.c_str());
+        fprintf(stderr, "%s", helpstr.c_str());
         exit(0);
     } else {
         fprintf(stderr, "Invalid command. Help follows:\n\n");
-        fprintf(stderr, helpstr.c_str());
+        fprintf(stderr, "%s", helpstr.c_str());
         exit(1);
     }
 

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -102,6 +102,13 @@ void extract_main (po::parsed_options parsed) {
     bool collapse_tree = vm["collapse-tree"].as<bool>();
     bool no_genotypes = vm["no-genotypes"].as<bool>();
     uint32_t num_threads = vm["threads"].as<uint32_t>();
+    //check that at least one of the output filenames (things which take dir_prefix)
+    //are set before proceeding. 
+    std::vector<std::string> outs = {sample_path_filename, clade_path_filename, tree_filename, vcf_filename, output_mat_filename};
+    if (!std::any_of(outs.begin(), outs.end(), [=](std::string f){return f != dir_prefix;})) {
+        fprintf(stderr, "ERROR: No output files requested!\n");
+        exit(1);
+    }
 
     tbb::task_scheduler_init init(num_threads);
 
@@ -141,7 +148,13 @@ void extract_main (po::parsed_options parsed) {
         //so I create a vector which represents all samples in both, then intersect that vector with the samples selected otherwise
         std::vector<std::string> samples_in_clade;
         for (auto cname: clades) {
+            fprintf(stderr, "Getting member samples of clade %s\n", cname.c_str());
             auto csamples = get_clade_samples(T, cname);
+            if (csamples.size() == 0) {
+                //warning because they may want the other clade they indicated and it can proceed with that
+                //itll error down the line if this was the only one they passed in and it leaves them with no samples
+                fprintf(stderr, "WARNING: Clade %s is not detected in the input tree!\n", cname.c_str());
+            }
             samples_in_clade.insert(samples_in_clade.end(), csamples.begin(), csamples.end());
         }
         //remove duplicate samples
@@ -172,7 +185,11 @@ void extract_main (po::parsed_options parsed) {
 
         std::vector<std::string> samples_with_mutation;
         for (auto mname: mutations) {
+            fprintf(stderr, "Getting samples with mutation %s\n", mname.c_str());
             auto msamples = get_mutation_samples(T, mname);
+            if (msamples.size() == 0) {
+                fprintf(stderr, "WARNING: No samples with mutation %s found in tree!\n", mname.c_str());
+            }
             samples_with_mutation.insert(samples_with_mutation.end(), msamples.begin(), msamples.end());
         }
         //remove duplicate samples
@@ -266,9 +283,6 @@ void extract_main (po::parsed_options parsed) {
         //run filter master again
         subtree = filter_master(subtree, rep_samples, false);
     }
-    //adding a bool to sanity check that the user actually requested some kind of output
-    bool wrote_output = false;
-
     //if additional information was requested, save it to the target files
     if (sample_path_filename != "./" || clade_path_filename != "./") {
         timer.Start();
@@ -280,7 +294,6 @@ void extract_main (po::parsed_options parsed) {
                 outfile << mstr << "\n";
             }
             outfile.close();
-            wrote_output = true;
         }
         if (clade_path_filename != "") {
             //need to get the set of all clade annotations currently in the tree for the clade_paths function
@@ -308,7 +321,6 @@ void extract_main (po::parsed_options parsed) {
                 outfile << cstr;
             }
             outfile.close(); 
-            wrote_output = true;
         }
         fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
     }
@@ -316,7 +328,6 @@ void extract_main (po::parsed_options parsed) {
     if (vcf_filename != dir_prefix) {
         fprintf(stderr, "Generating VCF of final tree\n");
         make_vcf(subtree, vcf_filename, no_genotypes);
-        wrote_output = true;
     }
     if (tree_filename != dir_prefix) {
         fprintf(stderr, "Generating Newick file of final tree\n");
@@ -324,7 +335,6 @@ void extract_main (po::parsed_options parsed) {
         fprintf(tree_file, "%s\n",
             MAT::get_newick_string(subtree, true, true, true).c_str());
         fclose(tree_file);        
-        wrote_output = true;
     }
     //and save a MAT if that was set
     if (output_mat_filename != dir_prefix) {
@@ -335,10 +345,6 @@ void extract_main (po::parsed_options parsed) {
         }
         MAT::save_mutation_annotated_tree(subtree, output_mat_filename);
         fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
-        wrote_output = true;
-    }
-    if (!wrote_output) {
-        fprintf(stderr, "WARNING: No output files requested!\n");
     }
 }
 

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -42,7 +42,7 @@ po::variables_map parse_extract_command(po::parsed_options parsed) {
         ("clade-paths,C", po::value<std::string>()->default_value(""),
         "Write the path of mutations defining each clade in the tree after sample selection to the target file.")
         ("all-paths,A", po::value<std::string>()->default_value(""),
-        "Write the path of mutations defining each node in the selected tree to the target file.")
+        "Write mutations assigned to each node in the selected tree to the target file.")
         ("write-vcf,v", po::value<std::string>()->default_value(""),
          "Output VCF file representing selected subtree. Default is full tree")
         ("no-genotypes,n", po::bool_switch(),

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -184,7 +184,6 @@ void extract_main (po::parsed_options parsed) {
             mutations.push_back(m);
         }
         assert (mutations.size() > 0);
-        //std::cerr << mutations[0];
 
         std::vector<std::string> samples_with_mutation;
         for (auto mname: mutations) {
@@ -286,6 +285,8 @@ void extract_main (po::parsed_options parsed) {
         auto rep_samples = get_clade_representatives(subtree);
         //run filter master again
         subtree = filter_master(subtree, rep_samples, false);
+        //overwrite samples with new subset
+        samples = rep_samples;
     }
     //if additional information was requested, save it to the target files
     if (sample_path_filename != dir_prefix || clade_path_filename != dir_prefix || all_path_filename != dir_prefix) {
@@ -373,7 +374,7 @@ int main (int argc, char** argv) {
     po::parsed_options parsed = po::command_line_parser(argc, argv).options(global).positional(pos).allow_unregistered().run();
     //this help string shows up over and over, lets just define it once
     std::string helpstr = "matUtils has several valid subcommands: \n\n"
-        "extract: subsets the input MAT on various conditions and/or converts to other formats (MAT, newick, VCF, etc)\n\n"
+        "extract: subsets the input MAT on various conditions and/or converts to other formats (newick, VCF, etc)\n\n"
         "summary: calculates basic statistics and counts members in the input MAT\n\n"
         "annotate: assigns clade identities to nodes, directly or by inference\n\n"
         "uncertainty: calculates sample placement uncertainty metrics and writes the results to tsv\n\n"

--- a/src/matUtils/summary.cpp
+++ b/src/matUtils/summary.cpp
@@ -66,7 +66,6 @@ void write_clade_table(MAT::Tree& T, std::string filename) {
     cladefile << "clade\tcount\n";
     //clades will be a map object.
     std::map<std::string, size_t> cladecounts;
-    std::cerr << T.root->clade_annotations[0] << T.root->clade_annotations[1] << "\n";
     auto dfs = T.depth_first_expansion();
     for (auto s: dfs) {
         std::vector<std::string> canns = s->clade_annotations;


### PR DESCRIPTION
This PR is fairly small. 

It has one primary new feature, which is a new argument for extract which writes the mutations assigned to every node across a subtree/tree in dfs order to a text file (-A).

It includes additional warning messages and verbosity around clade and sample selection, especially when multiple clades/mutations are selected and at least one of them is invalid/has no samples associated with it. Choosing some kind of output argument is also now a requirement and extract will throw an error if no valid output is selected before calculating anything.

BUGS FIXED:
1. Excessive samples names being printed when representative tree output is selected alongside -S for sample paths
2. Use of output directory option when not setting -S or -C tries to write to an invalid file name
3. Clade path output (-C) prints header incorrectly
4. Multiple clade path annotations with the same root node create garbled string output with -C
5. Compilation warnings around help string printing
6. An unremoved debug statement

Disregard any weirdness in commit authorship on the part of Git. I’ve started using a new macbook as my primary development environment and the way it signed commits was weird until I reconfigured it.

The next PR should include a refactor where extract main code is placed into its own module and a rework to summary to use an output directory and to include a function which identifies aberrant nodes or samples.
