### PR TITLE
New extract arguments, updated help messages, and a couple bugfixes

### DIFF
--- a/src/matUtils/convert.cpp
+++ b/src/matUtils/convert.cpp
@@ -341,7 +341,7 @@ std::string MAT_to_json(MAT::Tree T ) { /// write version and meta dicts first:
 
 void make_json ( MAT::Tree T, std::string json_filename ){
     std::string json_str = MAT_to_json( T ) ;
-    auto json_filepath = "./" + json_filename ;
+    auto json_filepath = json_filename ;
     std::ofstream json_file_ofstream ;
     json_file_ofstream.open( json_filepath ) ;
     json_file_ofstream << json_str ;

--- a/src/matUtils/convert.cpp
+++ b/src/matUtils/convert.cpp
@@ -341,9 +341,8 @@ std::string MAT_to_json(MAT::Tree T ) { /// write version and meta dicts first:
 
 void make_json ( MAT::Tree T, std::string json_filename ){
     std::string json_str = MAT_to_json( T ) ;
-    auto json_filepath = json_filename ;
     std::ofstream json_file_ofstream ;
-    json_file_ofstream.open( json_filepath ) ;
+    json_file_ofstream.open( json_filename ) ;
     json_file_ofstream << json_str ;
     json_file_ofstream.close() ;
 }

--- a/src/matUtils/extract.cpp
+++ b/src/matUtils/extract.cpp
@@ -115,7 +115,7 @@ void extract_main (po::parsed_options parsed) {
     uint32_t num_threads = vm["threads"].as<uint32_t>();
     //check that at least one of the output filenames (things which take dir_prefix)
     //are set before proceeding. 
-    std::vector<std::string> outs = {sample_path_filename, clade_path_filename, all_path_filename, tree_filename, vcf_filename, output_mat_filename, json_filename};
+    std::vector<std::string> outs = {sample_path_filename, clade_path_filename, all_path_filename, tree_filename, vcf_filename, output_mat_filename, json_filename, used_sample_filename};
     if (!std::any_of(outs.begin(), outs.end(), [=](std::string f){return f != dir_prefix;})) {
         fprintf(stderr, "ERROR: No output files requested!\n");
         exit(1);

--- a/src/matUtils/extract.cpp
+++ b/src/matUtils/extract.cpp
@@ -19,6 +19,8 @@ po::variables_map parse_extract_command(po::parsed_options parsed) {
         "Select samples by whether they have less than the maximum indicated number of equally parsimonious placements. Note: calculation adds significantly to runtime.")
         ("max-parsimony,a", po::value<int>()->default_value(-1),
         "Select samples by whether they have less than the maximum indicated parsimony score (terminal branch length)")
+        ("max-branch-length,b", po::value<int>()->default_value(-1),
+        "Remove samples which have branches of greater than the indicated length in their ancestry.")
         ("nearest-k,k", po::value<std::string>()->default_value(""),
         "Select a sample ID and the nearest k samples to it, formatted as sample:k. E.g. -k sample_1:50 gets sample 1 and the nearest 50 samples to it as a subtree.")
         ("get-representative,r", po::bool_switch(),
@@ -29,6 +31,8 @@ po::variables_map parse_extract_command(po::parsed_options parsed) {
         "Resolve all polytomies by assigning branch length 0 relationships arbitrarily. Applied after selection; prevents recondensing of the MAT.")
         ("output-directory,d", po::value<std::string>()->default_value("./"),
         "Write output files to the target directory. Default is current directory.")
+        ("used-samples,u", po::value<std::string>()->default_value(""),
+        "Write a simple text file of selected sample ids.")
         ("sample-paths,S", po::value<std::string>()->default_value(""),
         "Write the path of mutations defining each sample in the subtree.")
         ("clade-paths,C", po::value<std::string>()->default_value(""),
@@ -83,6 +87,7 @@ void extract_main (po::parsed_options parsed) {
     std::string clade_choice = vm["clade"].as<std::string>();
     std::string mutation_choice = vm["mutation"].as<std::string>();
     int max_parsimony = vm["max-parsimony"].as<int>();
+    int max_branch = vm["max-branch-length"].as<int>();
     size_t max_epps = vm["max-epps"].as<size_t>();
     bool prune_samples = vm["prune"].as<bool>();
     bool get_representative = vm["get-representative"].as<bool>();
@@ -97,6 +102,7 @@ void extract_main (po::parsed_options parsed) {
     path = boost::filesystem::canonical(dir_prefix);
     dir_prefix = path.generic_string();
     dir_prefix += "/";
+    std::string used_sample_filename = dir_prefix + vm["used-samples"].as<std::string>();
     std::string sample_path_filename = dir_prefix + vm["sample-paths"].as<std::string>();
     std::string clade_path_filename = dir_prefix + vm["clade-paths"].as<std::string>();
     std::string all_path_filename = dir_prefix + vm["all-paths"].as<std::string>();
@@ -243,6 +249,14 @@ void extract_main (po::parsed_options parsed) {
             }
         }
     } 
+    if (max_branch >= 0) {
+        //intersection is built into this one because its a significant runtime gain to not rsearch samples I won't use anyways
+        samples = get_short_steppers(T, samples, max_branch);
+        if (samples.size() == 0) {
+            fprintf(stderr, "ERROR: No samples fulfill selected criteria. Change arguments and try again\n");
+            exit(1);
+        }
+    }
     if (max_epps > 0) {
         //this specific sample parser only calculates for values present in samples argument
         //so it doesn't need any intersection code
@@ -318,6 +332,16 @@ void extract_main (po::parsed_options parsed) {
         samples = rep_samples;
     }
     //if additional information was requested, save it to the target files
+    //starting with dumping the set of samples used to a plain text file
+    //this is intended for use with uncertainty and perhaps repeated extract commands
+    if (used_sample_filename != dir_prefix) {
+        //not bothering timing it because this will always be very fast since its an extremely simple non-MAT operation
+        fprintf(stderr, "Dumping selected samples to file...\n");
+        std::ofstream outfile (used_sample_filename);
+        for (auto s: samples) {
+            outfile << s << "\n";
+        }
+    }
     if (sample_path_filename != dir_prefix || clade_path_filename != dir_prefix || all_path_filename != dir_prefix) {
         timer.Start();
         fprintf(stderr,"Retriving path information...\n");
@@ -373,7 +397,7 @@ void extract_main (po::parsed_options parsed) {
     }
     if (json_filename != dir_prefix) {
         fprintf(stderr, "Generating JSON of final tree\n");
-        make_json(subtree, json_filename ) ;
+        make_json(subtree, json_filename);
     }
     if (tree_filename != dir_prefix) {
         fprintf(stderr, "Generating Newick file of final tree\n");

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -16,20 +16,23 @@ int main (int argc, char** argv) {
     po::variables_map vm;
     po::parsed_options parsed = po::command_line_parser(argc, argv).options(global).positional(pos).allow_unregistered().run();
     //this help string shows up over and over, lets just define it once
-    std::string helpstr = "matUtils has several valid subcommands: \n\n"
-        "extract: subsets the input MAT on various conditions and/or converts to other formats (newick, VCF, JSON etc)\n\n"
-        "summary: calculates basic statistics and counts members in the input MAT\n\n"
-        "annotate: assigns clade identities to nodes, directly or by inference\n\n"
-        "uncertainty: calculates sample placement uncertainty metrics and writes the results to tsv\n\n"
-        "mask: masks the mutations specific to the restricted set of input samples\n\n"
-        "Individual command options can be accessed with matUtils command --help, e.g. matUtils annotate --help will show annotation-specific help messages.\n\n";
-    
+    std::string cnames[6] = {"COMMAND","summary","extract","annotate","uncertainty","mask"};
+    std::string chelp[6] = {
+        "DESCRIPTION\n\n",
+        "calculates basic statistics and counts samples, mutations, and clades in the input MAT\n\n",
+        "subsets the input MAT on various conditions and/or converts to other formats (newick, VCF, JSON)\n\n",
+        "assigns clade identities to nodes, directly or by inference\n\n",
+        "calculates sample placement uncertainty metrics and writes the results to tsv\n\n",
+        "masks the input samples\n\n"
+    };
     try {
         po::store(parsed, vm);
         cmd = vm["command"].as<std::string>();
     } catch (...) { //not sure this is the best way to catch it when matUtils is called with no positional arguments.
-        fprintf(stderr, "No command selected. Help follows:\n\n");
-        fprintf(stderr, "%s", helpstr.c_str());
+        fprintf(stderr, "\nNo command selected. Help follows:\n\n");
+        for (int i = 0; i < 6; ++i) {
+            fprintf(stderr, "%-15s\t%s", cnames[i].c_str(), chelp[i].c_str());
+        }
         //0 when no command is selected because that's what passes tests.
         exit(0);
     }
@@ -44,11 +47,16 @@ int main (int argc, char** argv) {
     } else if (cmd == "summary") {
         summary_main(parsed);
     } else if (cmd == "help") { 
-        fprintf(stderr, "%s", helpstr.c_str());
+        fprintf(stderr, "\n");
+        for (int i = 0; i < 6; ++i) {
+            fprintf(stderr, "%-15s\t%s", cnames[i].c_str(), chelp[i].c_str());
+        }        
         exit(0);
     } else {
-        fprintf(stderr, "Invalid command. Help follows:\n\n");
-        fprintf(stderr, "%s", helpstr.c_str());
+        fprintf(stderr, "\nInvalid command. Help follows:\n\n");
+        for (int i = 0; i < 6; ++i) {
+            fprintf(stderr, "%-15s\t%s", cnames[i].c_str(), chelp[i].c_str());
+        }        
         exit(1);
     }
 

--- a/src/matUtils/select.cpp
+++ b/src/matUtils/select.cpp
@@ -211,3 +211,34 @@ std::vector<std::string> get_nearby (MAT::Tree T, std::string sample_id, int num
     std::vector<std::string> neighborhood_leaves(all_leaves.begin() + subset_start, all_leaves.begin() + subset_end);
     return neighborhood_leaves;
 }
+
+std::vector<std::string> get_short_steppers(MAT::Tree T, std::vector<std::string> samples_to_check, int max_mutations) {
+    //for each sample in samples_to_check, this function rsearches along that samples history in the tree
+    //if any of the ancestors have greater than max_mutations mutations, then it breaks and marks that sample as a toss
+    //including the sample itself. It takes a list of samples to check because rsearching is not a super fast process
+    //and we may as well be efficient about it when time permits.
+    std::vector<std::string> good_samples;
+    if (samples_to_check.size() == 0) {
+        //if nothing is passed in, then check the whole tree.
+        samples_to_check = T.get_leaves_ids();
+    }
+    for (auto s: samples_to_check) {
+        auto n = T.get_node(s);
+        //check this sample immediately before spending cycles getting the ancestors
+        if (n->mutations.size() > max_mutations) {
+            continue;
+        }
+        auto anc_nodes = T.rsearch(s);
+        bool badanc = false;
+        for (auto an: anc_nodes) {
+            if (an->mutations.size() > max_mutations) {
+                badanc = true;
+                continue;
+            }
+        }
+        if (!badanc) {
+            good_samples.push_back(s);
+        }
+    }
+    return good_samples;
+}

--- a/src/matUtils/select.hpp
+++ b/src/matUtils/select.hpp
@@ -7,3 +7,4 @@ std::vector<std::string> get_parsimony_samples (MAT::Tree T, float max_parsimony
 std::vector<std::string> get_clade_representatives(MAT::Tree T);
 std::vector<std::string> sample_intersect (std::vector<std::string> samples, std::vector<std::string> nsamples);
 std::vector<std::string> get_nearby (MAT::Tree T, std::string sample_id, int number_to_get);
+std::vector<std::string> get_short_steppers(MAT::Tree T, std::vector<std::string> samples_to_check, int max_mutations);

--- a/src/matUtils/summary.cpp
+++ b/src/matUtils/summary.cpp
@@ -190,10 +190,10 @@ void summary_main(po::parsed_options parsed) {
     if (get_all) {
         //if this is set, overwrite with default names for all output
         //and since these names are non-empty, all will be generated
-        samples = dir_prefix + "samples.txt";
-        clades = dir_prefix + "clades.txt";
-        mutations = dir_prefix + "mutations.txt";
-        aberrant = dir_prefix + "aberrant.txt";
+        samples = dir_prefix + "samples.tsv";
+        clades = dir_prefix + "clades.tsv";
+        mutations = dir_prefix + "mutations.tsv";
+        aberrant = dir_prefix + "aberrant.tsv";
     }
     tbb::task_scheduler_init init(num_threads);
 

--- a/src/matUtils/uncertainty.cpp
+++ b/src/matUtils/uncertainty.cpp
@@ -434,8 +434,7 @@ void uncertainty_main(po::parsed_options parsed) {
     }
     if (get_parsimony){
         fprintf(stdout, "Total Tree Parsimony %ld\n", T.get_parsimony_score());
-    }
-    if (fepps != "" && fneigh != "" && !get_parsimony) {
+    } else if (fepps.size() == 0 && fneigh.size() == 0) {
         fprintf(stderr, "No actions chosen. Review arguments\n");
         exit(1);
     }


### PR DESCRIPTION
This PR includes two new arguments to extract, -u and -b. 

-b filters on the maximum number of mutations per step (branch length) in the history of the sample back to the root and is a result of a discussion with Angie and Russ about how to approach samples with odd histories. This does actually count the number of unmasked mutations and not just look at the branch length attribute (open to opinions on this decision). Max branch length *can* be zero, and if its set as such it gets samples which are 0 parsimony, no mutation children of the root node (identical to reference).

-u is a simple new output of just dumping the identifiers of selected samples to a text file; this is something I realized would be useful as I was working on example workflows in the wiki, specifically for supporting running matUtils uncertainty on an extracted subset of samples. It could also be useful for selecting from the tree based on something that's computationally intensive to filter on, if you then want to apply or not apply other filters in multiple runs of extract down the line without recalculating this set.

It also includes an update to the help strings when "matUtils", "matUtils help", or "matUtils *some non-command*" are called. They are now printed as columns of command and description with summary at the top.

Finally, there are a couple bugfixes:
1. correctly assigning output directory when not explicitly defined for Bryan's new JSON writer.
2. fixing a failure to recognize actions taken in matUtils uncertainty.