### PR TITLE
A very, very small PR to significantly improve extract -p performance 

### DIFF
--- a/src/matUtils/extract.cpp
+++ b/src/matUtils/extract.cpp
@@ -275,9 +275,10 @@ void extract_main (po::parsed_options parsed) {
     if (prune_samples) {
         fprintf(stderr, "Sample pruning requested...\n");
         std::vector<std::string> nsamples;
+        std::unordered_set<std::string> sample_set(samples.begin(), samples.end());
         for (auto s: T.get_leaves_ids()) {
             //for every sample in the tree, if that sample is NOT in the selected set, save it
-            if (std::find(samples.begin(), samples.end(), s) == samples.end()) {
+            if (sample_set.find(s) == sample_set.end()) {
                 nsamples.push_back(s);
             }
         }


### PR DESCRIPTION
Bryan brought to my attention during benchmarking that I had a really naive implementation related to --prune in matUtils extract (checking membership in a vector instead of a set, quadratic when it could be linear). I've made a very simple change- to using std::unordered_set- which significantly reduces total runtime for --prune commands with large sample queries. This was a naive mistake on my part and I will endeavor not to repeat it. I'm opening the PR now to make sure it gets into the next matUtils release.