### PR TITLE
.branch_length is dead, long live .mutations.size()

### DIFF
--- a/src/matUtils/README.md
+++ b/src/matUtils/README.md
@@ -23,11 +23,17 @@ This command selects subtrees from the MAT based on clade identification, sample
 
 **-a**: Select samples to extract by whether their parsimony score (terminal branch length) is less than the indicated value.
 
+**-b**: Remove samples with have a branch of greater than the indicated length somewhere in their ancestry.
+
+**-k**: Select a specific sample and the X closest samples, formatted as "Samplename:X"
+
 **-r**: Automatically select two samples per unique clade identifier to extract.
 
 **-p**: Prune the samples indicated by other arguments instead of extracting them to create the subtree.
 
 **-R**: Resolve polytomies by insertion of internal nodes with branch length 0. Prevents condensed tree output. Intended for compatibility with software requiring fully resolved trees.
+
+**-u**: Write a simple text file containing selected sample names.
 
 **-d**: Set the directory to save output files. Directory must already exist. Default is current directory
 

--- a/src/matUtils/filter.cpp
+++ b/src/matUtils/filter.cpp
@@ -99,8 +99,6 @@ void resolve_polytomy(MAT::Tree* T, std::vector<MAT::Node*> polytomy_nodes) {
     //except for the last one, which will go to the last parent in line (index - 1),
     //as the last parent can support two children.
     for (size_t i=1; i<polytomy_nodes.size()-1; i++) {
-        //the node mover routine resets the branch length and we don't want to do that
-        //save it, move, then reassign the branch length
         T->move_node(polytomy_nodes[i]->identifier, new_parents[i]->identifier, false);
     }
     T->move_node(polytomy_nodes.back()->identifier, new_parents.back()->identifier, false);

--- a/src/matUtils/filter.cpp
+++ b/src/matUtils/filter.cpp
@@ -101,13 +101,9 @@ void resolve_polytomy(MAT::Tree* T, std::vector<MAT::Node*> polytomy_nodes) {
     for (size_t i=1; i<polytomy_nodes.size()-1; i++) {
         //the node mover routine resets the branch length and we don't want to do that
         //save it, move, then reassign the branch length
-        float length_to_keep = polytomy_nodes[i]->branch_length;
         T->move_node(polytomy_nodes[i]->identifier, new_parents[i]->identifier, false);
-        polytomy_nodes[i]->branch_length = length_to_keep;
     }
-    float length_to_keep = polytomy_nodes.back()->branch_length;
     T->move_node(polytomy_nodes.back()->identifier, new_parents.back()->identifier, false);
-    polytomy_nodes.back()->branch_length = length_to_keep;
 }
 
 MAT::Tree resolve_all_polytomies(MAT::Tree T) {

--- a/src/matUtils/select.cpp
+++ b/src/matUtils/select.cpp
@@ -104,7 +104,7 @@ std::vector<std::string> get_parsimony_samples (MAT::Tree T, float max_parsimony
     std::vector<std::string> good_samples;
     auto dfs = T.get_leaves();
     for (auto n: dfs) {
-        if (n->branch_length <= max_parsimony) {
+        if (n->mutations.size() <= max_parsimony) {
             good_samples.push_back(n->identifier);
         }
     }

--- a/src/matUtils/select.cpp
+++ b/src/matUtils/select.cpp
@@ -99,12 +99,12 @@ std::vector<std::string> get_mutation_samples (MAT::Tree T, std::string mutation
     return good_samples;
 }
 
-std::vector<std::string> get_parsimony_samples (MAT::Tree T, float max_parsimony) {
+std::vector<std::string> get_parsimony_samples (MAT::Tree T, int max_parsimony) {
     //simple selection- get samples which have less than X parsimony score (e.g. branch length)
     std::vector<std::string> good_samples;
     auto dfs = T.get_leaves();
     for (auto n: dfs) {
-        if (n->mutations.size() <= max_parsimony) {
+        if (n->mutations.size() <= static_cast<size_t>(max_parsimony)) {
             good_samples.push_back(n->identifier);
         }
     }

--- a/src/matUtils/select.hpp
+++ b/src/matUtils/select.hpp
@@ -3,7 +3,7 @@
 std::vector<std::string> read_sample_names (std::string sample_filename);
 std::vector<std::string> get_clade_samples (MAT::Tree T, std::string clade_name);
 std::vector<std::string> get_mutation_samples (MAT::Tree T, std::string mutation_id);
-std::vector<std::string> get_parsimony_samples (MAT::Tree T, float max_parsimony);
+std::vector<std::string> get_parsimony_samples (MAT::Tree T, int max_parsimony);
 std::vector<std::string> get_clade_representatives(MAT::Tree T);
 std::vector<std::string> sample_intersect (std::vector<std::string> samples, std::vector<std::string> nsamples);
 std::vector<std::string> get_nearby (MAT::Tree T, std::string sample_id, int number_to_get);

--- a/src/matUtils/summary.cpp
+++ b/src/matUtils/summary.cpp
@@ -58,7 +58,7 @@ void write_sample_table(MAT::Tree& T, std::string filename) {
     for (auto s: dfs) {
         if (s->is_leaf()) {
             //leaves are samples (on the uncondensed tree)
-            samplefile << s->identifier << "\t" << s->branch_length << "\n";
+            samplefile << s->identifier << "\t" << s->mutations.size() << "\n";
         }        
     }
     fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
@@ -158,7 +158,7 @@ void write_aberrant_table(MAT::Tree& T, std::string filename) {
         } else {
             badfile << n->identifier << "\tduplicate-node-id\n";
         }
-        if (n->branch_length == 0 && !n->is_leaf() && !n->is_root()) {
+        if (n->mutations.size() == 0 && !n->is_leaf() && !n->is_root()) {
             badfile << n->identifier << "\tinternal-branch-length-0\n";
         }
         if (n->mutations.size() == 0 && !n->is_leaf() && !n->is_root()) {

--- a/src/matUtils/summary.cpp
+++ b/src/matUtils/summary.cpp
@@ -159,9 +159,6 @@ void write_aberrant_table(MAT::Tree& T, std::string filename) {
             badfile << n->identifier << "\tduplicate-node-id\n";
         }
         if (n->mutations.size() == 0 && !n->is_leaf() && !n->is_root()) {
-            badfile << n->identifier << "\tinternal-branch-length-0\n";
-        }
-        if (n->mutations.size() == 0 && !n->is_leaf() && !n->is_root()) {
             badfile << n->identifier << "\tinternal-no-mutations\n";
         }
     }

--- a/src/matUtils/uncertainty.cpp
+++ b/src/matUtils/uncertainty.cpp
@@ -28,7 +28,7 @@ std::vector<float> get_all_distances(MAT::Node* target, std::vector<std::vector<
                 //stop iterating when its reached the indicated common ancestor (remember, path is sorted nearest to root)
                 break; 
             }
-            tdist += paths[p][i]->branch_length;
+            tdist += paths[p][i]->mutations.size();
 
         //then record the total distance in distvs
         distvs.emplace_back(tdist);


### PR DESCRIPTION
This PR is a revision of behavior around using the node branch length attribute where its not appropriate or relevant in matUtils, replacing it instead with the more consistently parsimony-relevant mutation vector size. Also includes some README updates that slipped through.