### PR TITLE
Typo fix for '#if DEBUG' code

### DIFF
--- a/src/usher.cpp
+++ b/src/usher.cpp
@@ -769,8 +769,8 @@ int main(int argc, char** argv) {
                 // best node and the list of mutations at the best node
 #if DEBUG == 1
                 fprintf (stderr, "Sample mutations:\t");
-                if (missing_sample[s].mutations.size() > 0) {
-                    for (auto m: missing_sample[s].mutations) {
+                if (missing_samples[s].mutations.size() > 0) {
+                    for (auto m: missing_samples[s].mutations) {
                         if (m.is_missing) {
                             continue;
                         }


### PR DESCRIPTION
A couple lines of '#if DEBUG' code had "missing_sample" instead of "missing_samples", so there was a compile error when compiling with DEBUG=1.  