### PR TITLE
Adding basic tree simplification to matUtils mask

### DIFF
--- a/src/matUtils/mask.cpp
+++ b/src/matUtils/mask.cpp
@@ -12,6 +12,10 @@ po::variables_map parse_mask_command(po::parsed_options parsed) {
          "Input mutation-annotated tree file [REQUIRED]")
         ("output-mat,o", po::value<std::string>()->required(),
          "Path to output masked mutation-annotated tree file [REQUIRED]")
+        ("simplify,S", po::bool_switch(),
+        "Use to automatically mask identifying information from the tree, including all sample names and private mutations.")
+        // ("create-pseudosample,p", po::value<size_t>()->default_value(0),
+        // "Set to a positive integer to collapse groups of p samples into single pseudosamples containing their mutational information.")
         ("restricted-samples,s", po::value<std::string>()->default_value(""), 
          "Sample names to restrict. Use to perform masking") 
         ("rename-samples,r", po::value<std::string>()->default_value(""), 
@@ -46,6 +50,8 @@ void mask_main(po::parsed_options parsed) {
     std::string input_mat_filename = vm["input-mat"].as<std::string>();
     std::string output_mat_filename = vm["output-mat"].as<std::string>();
     std::string samples_filename = vm["restricted-samples"].as<std::string>();
+    // size_t pseudosample_size = vm["create-pseudosample"].as<size_t>();
+    bool simplify = vm["simplify"].as<bool>();
     std::string rename_filename = vm["rename-samples"].as<std::string>();
     uint32_t num_threads = vm["threads"].as<uint32_t>();
 
@@ -60,8 +66,18 @@ void mask_main(po::parsed_options parsed) {
 
     // If a restricted samples file was provided, perform masking procedure
     if (samples_filename != "") {
-        fprintf(stderr, "Performing Masking\n");
+        fprintf(stderr, "Performing Masking...\n");
         restrictSamples(samples_filename, T);
+    }
+    // if (pseudosample_size > 0) {
+    //     fprintf(stderr, "Collapsing groups into pseudosamples...\n");
+    //     create_pseudosamples(&T, pseudosample_size);
+    // }
+    if (simplify) {
+        fprintf(stderr, "Removing identifying information...\n");
+        simplify_tree(&T);
+        fprintf(stderr, "Recondensing leaves..\n");
+        T.condense_leaves();
     }
 
     // If a rename file was provided, perform renaming procedure
@@ -75,6 +91,59 @@ void mask_main(po::parsed_options parsed) {
         fprintf(stderr, "Saving Final Tree\n");
         MAT::save_mutation_annotated_tree(T, output_mat_filename);
     }    
+}
+
+void create_pseudosamples(MAT::Tree* T, size_t min_terminals) {
+    //this function goes through the tree and collapses groups of leaves into pseudosamples
+    //each internal node with exactly min_terminals is collapsed into a single pseudosample
+    //first, we iterate through and record all the points we're going to collapse to
+    //in order to avoid issues with a changing DFS as we iterate
+    std::vector<MAT::Node*> targets;
+    for (auto n: T->breadth_first_expansion()) {
+        if ((T->get_leaves(n->identifier).size() == min_terminals) | (n->children.size() >= min_terminals)) {
+            //we check on either the total terminals being exactly equal to the minimum cutoff
+            //or collapse an immediate polytomy which may have more than the minimum terminals
+            //we allow >= for immediate children only.
+            //record the actual pointer.
+            targets.push_back(n);
+        }
+    }
+    fprintf(stderr, "DEBUG: %ld nodes targeted for collapse points\n", targets.size());
+    for (auto t: targets) {
+        MAT::Node* new_node = T->create_node("pseudo_" + t->identifier, t->parent, t->branch_length);
+
+        auto subtree = T->depth_first_expansion(t);
+        for (auto c: subtree) {
+            //shove its mutations into the target node
+            for (auto m: c->mutations) {
+                new_node->mutations.push_back(m);
+            }
+        }
+        //delete the original node. this will remove all its children as well.
+        T->remove_node(t->identifier, true);
+        //check that we have a leaf.
+        assert (new_node->is_leaf());
+    }
+}
+
+void simplify_tree(MAT::Tree* T) {
+    /*
+    This function is intended for the removal of potentially problematic information from the tree while keeping the core structure.
+    This renames all samples to arbitrary numbers, similar to internal nodes, and removes sample mutations.
+    */
+    auto all_leaves = T->get_leaves();
+    std::random_shuffle(all_leaves.begin(), all_leaves.end());
+    int rid = 0;
+    for (auto l: all_leaves) {
+        //only leaves need to have their information altered.
+        //remove the mutations first, then change the identifier.
+        l->mutations.clear();
+        std::stringstream nname;
+        //add the l to distinguish them from internal node IDs
+        nname << "l" << rid;
+        T->rename_node(l->identifier, nname.str());
+        rid++;
+    }
 }
 
 void renameSamples (std::string rename_filename, MAT::Tree& T) {

--- a/src/matUtils/mask.cpp
+++ b/src/matUtils/mask.cpp
@@ -54,6 +54,12 @@ void mask_main(po::parsed_options parsed) {
 
     tbb::task_scheduler_init init(num_threads);
 
+    //check for mutually exclusive arguments
+    if ((simplify) & (rename_filename != "")) {
+        //doesn't make any sense to rename nodes after you just scrambled their names. Or to rename them, then scramble them.
+        fprintf(stderr, "ERROR: Sample renaming and simplification are mutually exclusive operations. Review argument choices\n");
+        exit(1);
+    }
     // Load input MAT and uncondense tree
     MAT::Tree T = MAT::load_mutation_annotated_tree(input_mat_filename);
     //T here is the actual object.

--- a/src/matUtils/mask.hpp
+++ b/src/matUtils/mask.hpp
@@ -2,7 +2,6 @@
 
 po::variables_map parse_mask_command(po::parsed_options parsed);
 void mask_main(po::parsed_options parsed);
-void create_pseudosamples(MAT::Tree* T, size_t min_terminals);
 void simplify_tree(MAT::Tree* T);
 void restrictSamples (std::string samples_filename, MAT::Tree& T);
 void renameSamples(std::string rename_filename, MAT::Tree& T);

--- a/src/matUtils/mask.hpp
+++ b/src/matUtils/mask.hpp
@@ -2,5 +2,7 @@
 
 po::variables_map parse_mask_command(po::parsed_options parsed);
 void mask_main(po::parsed_options parsed);
+void create_pseudosamples(MAT::Tree* T, size_t min_terminals);
+void simplify_tree(MAT::Tree* T);
 void restrictSamples (std::string samples_filename, MAT::Tree& T);
 void renameSamples(std::string rename_filename, MAT::Tree& T);


### PR DESCRIPTION
This relatively straightforward feature renames all samples to random strings and removes all their mutations. Feature is a request from Angie to support Pangolin lineage assignments and other GISAID related concerns. It can't be set at the same time as renaming because it scrambles sample names.

A simplified tree is substantially smaller in file size than the full tree, given the ability to condense previously uncondensable samples, and saves/loads more quickly. Samples placed on it are likely to have equal or higher parsimony scores to a similar placement on the full tree, equal where they are off preexisting internal nodes and higher where they could have generated a new internal node with a sample that shares their otherwise private mutations in the full tree. Clade lineage assignment is unaffected in testing and approximate placement, despite the changes in parsimony, is essentially the same.

Future expansions for this functionality would involve breaking down internal nodes as well where they are not phylogenetically informative for more than a few samples, but this is a straightforward initial draft for immediate use.