### PR TITLE
matUtils uncertainty rework, new selection features, general tweaks

### DIFF
--- a/src/matUtils/select.cpp
+++ b/src/matUtils/select.cpp
@@ -1,5 +1,4 @@
 #include "select.hpp"
-#include <regex>
 /*
 Functions in this module take a variety of arguments, usually including a MAT
 and return a set of samples as a std::vector<std::string>

--- a/src/matUtils/select.hpp
+++ b/src/matUtils/select.hpp
@@ -1,11 +1,13 @@
 #include "common.hpp"
 
 std::vector<std::string> read_sample_names (std::string sample_filename);
-std::vector<std::string> get_clade_samples (MAT::Tree T, std::string clade_name);
-std::vector<std::string> get_mutation_samples (MAT::Tree T, std::string mutation_id);
-std::vector<std::string> get_parsimony_samples (MAT::Tree T, int max_parsimony);
-std::vector<std::string> get_clade_representatives(MAT::Tree T);
+std::vector<std::string> get_clade_samples (MAT::Tree* T, std::string clade_name);
+std::vector<std::string> get_mutation_samples (MAT::Tree* T, std::string mutation_id);
+std::vector<std::string> get_parsimony_samples (MAT::Tree* T, int max_parsimony);
+std::vector<std::string> get_clade_representatives(MAT::Tree* T);
 std::vector<std::string> sample_intersect (std::vector<std::string> samples, std::vector<std::string> nsamples);
 std::vector<std::string> get_nearby (MAT::Tree* T, std::string sample_id, int number_to_get);
-std::vector<std::string> get_short_steppers(MAT::Tree T, std::vector<std::string> samples_to_check, int max_mutations);
+std::vector<std::string> get_short_steppers(MAT::Tree* T, std::vector<std::string> samples_to_check, int max_mutations);
 std::map<std::string,std::map<std::string,std::string>> read_metafile(std::string metainf, std::set<std::string> samples_to_use);
+std::vector<std::string> get_sample_match(MAT::Tree* T, std::string substring);
+std::vector<std::string> fill_random_samples(MAT::Tree* T, std::vector<std::string> current_samples, size_t target_size);

--- a/src/matUtils/uncertainty.cpp
+++ b/src/matUtils/uncertainty.cpp
@@ -329,7 +329,7 @@ void findEPPs_wrapper (MAT::Tree Tobj, std::string sample_file, std::string fepp
             eppfile << node->identifier << "\t" << num_best << "\t" << neighborhood_size << "\n";
         }
         if (flocs != "") {
-            locfile << node->identifier << "\t" << "original" << "\n";
+            locfile << node->identifier << "\t" << node->identifier << "\n";
             for (auto pn: best_placements) {
                 locfile << pn->identifier << "\t" << node->identifier << "\n";
             }

--- a/src/matUtils/uncertainty.cpp
+++ b/src/matUtils/uncertainty.cpp
@@ -267,15 +267,12 @@ void findEPPs_wrapper (MAT::Tree Tobj, std::string sample_file, std::string fepp
     */
     timer.Start();
     std::ofstream eppfile;
-    // std::ofstream neighfile;
     eppfile.open(fepps);
     //add column names
-    //auspice doesn't care what's actually in column 1 name, but it does for column 2
     eppfile << "sample\tequally_parsimonius_placements\tneighborhood_size\n";
     //mapper code wants a pointer.
     MAT::Tree* T = &Tobj; 
 
-    //std::vector<MAT::Node*> fdfs;
     std::vector<std::string> samples;
     //read in the samples files and get the nodes corresponding to each sample.
     if (sample_file != "") { 
@@ -391,9 +388,7 @@ void uncertainty_main(po::parsed_options parsed) {
     po::variables_map vm = parse_uncertainty_command(parsed);
     std::string input_mat_filename = vm["input-mat"].as<std::string>();
     std::string sample_file = vm["samples"].as<std::string>();
-    // bool get_parsimony = vm["get-parsimony"].as<bool>();
     std::string fepps = vm["find-epps"].as<std::string>();
-    // std::string fneigh = vm["find-neighborhood"].as<std::string>();
     uint32_t num_threads = vm["threads"].as<uint32_t>();
 
     tbb::task_scheduler_init init(num_threads);

--- a/src/matUtils/uncertainty.cpp
+++ b/src/matUtils/uncertainty.cpp
@@ -269,7 +269,7 @@ void findEPPs_wrapper (MAT::Tree Tobj, std::string sample_file, std::string fepp
     std::ofstream eppfile;
     eppfile.open(fepps);
     //add column names
-    eppfile << "sample\tequally_parsimonius_placements\tneighborhood_size\n";
+    eppfile << "sample\tequally_parsimonious_placements\tneighborhood_size\n";
     //mapper code wants a pointer.
     MAT::Tree* T = &Tobj; 
 

--- a/src/matUtils/uncertainty.hpp
+++ b/src/matUtils/uncertainty.hpp
@@ -3,8 +3,8 @@
 std::vector<MAT::Node*> get_common_nodes (std::vector<std::vector<MAT::Node*>> nodepaths);
 std::vector<float> get_all_distances(MAT::Node* target, std::vector<std::vector<MAT::Node*>> paths);
 size_t get_neighborhood_size(std::vector<MAT::Node*> nodes, MAT::Tree* T);
-void findEPPs (MAT::Tree* T, MAT::Node* node, size_t* nbest, size_t* nsize);
-void findEPPs_wrapper (MAT::Tree Tobj, std::string sample_file, std::string fepps);
+std::vector<MAT::Node*> findEPPs (MAT::Tree* T, MAT::Node* node, size_t* nbest, size_t* nsize);
+void findEPPs_wrapper (MAT::Tree Tobj, std::string sample_file, std::string fepps, std::string flocs);
 std::vector<std::string> get_samples_epps (MAT::Tree* T, size_t max_epps, std::vector<std::string> to_check);
 po::variables_map parse_uncertainty_command(po::parsed_options parsed);
 void uncertainty_main(po::parsed_options parsed);

--- a/src/matUtils/uncertainty.hpp
+++ b/src/matUtils/uncertainty.hpp
@@ -3,8 +3,8 @@
 std::vector<MAT::Node*> get_common_nodes (std::vector<std::vector<MAT::Node*>> nodepaths);
 std::vector<float> get_all_distances(MAT::Node* target, std::vector<std::vector<MAT::Node*>> paths);
 size_t get_neighborhood_size(std::vector<MAT::Node*> nodes, MAT::Tree* T);
-void findEPPs (MAT::Tree* T, MAT::Node* node, bool get_nsize, size_t* nbest, size_t* nsize);
-void findEPPs_wrapper (MAT::Tree Tobj, std::string sample_file, std::string fepps, std::string fneigh);
-std::vector<std::string> get_samples_epps (MAT::Tree T, size_t max_epps, std::vector<std::string> to_check);
+void findEPPs (MAT::Tree* T, MAT::Node* node, size_t* nbest, size_t* nsize);
+void findEPPs_wrapper (MAT::Tree Tobj, std::string sample_file, std::string fepps);
+std::vector<std::string> get_samples_epps (MAT::Tree* T, size_t max_epps, std::vector<std::string> to_check);
 po::variables_map parse_uncertainty_command(po::parsed_options parsed);
 void uncertainty_main(po::parsed_options parsed);


### PR DESCRIPTION
This PR is focused on an overhaul to matUtils uncertainty, which combines the output files, so that both EPPs and neighborhood size are calculated and saved together into a single output file (compatible with -M on extract downstream!), and removes the total tree parsimony score option as matUtils summary does that now and the function is essentially deprecated. I also added an option to produce a two-column tsv of placement locations and original sample identifiers, including the original samples themselves, to improve equally parsimonious placement location visualizations. 

It also includes two new arguments for matUtils extract -H and -z. -H selects all samples for which the indicated string is a substring of the sample identifier (e.g. -H USA will get all samples with USA in the name). -z randomly adds or removes samples from the selected sample set until the sample set is the indicated size.

For example, if I want 100 samples from the USA, I can now use:
matUtils extract -i public.pb -z 100 -H USA -j random_USA.json

Or if I wanted 250 samples with as many samples from 1-15-21 that have G1234A as possible among them:
matUtils extract -i public.pb -z 250 -H 1-15-21 -m G1234A random_day_mutation.json

It also includes a few tweaks and getting ahead of some potential future bug issues, particularly changing the selection functions to take the tree by reference.

I will be updating the wiki, both for matUtils extract parameter sets and reworking the uncertainty tutorial to reflect the new command structure once/if this PR is merged.