### PR TITLE
Parallelize VCF dump

### DIFF
--- a/src/matUtils/convert.cpp
+++ b/src/matUtils/convert.cpp
@@ -257,7 +257,7 @@ void write_vcf_rows(std::ostream& vcf_file, MAT::Tree T, std::vector<MAT::Node*>
         std::string chrom = itr->first;
         std::vector<int8_t *> pos_genotypes = itr->second;
         uint pos=0;
-        tbb::parallel_pipeline(80,tbb::make_filter<void,uint>(tbb::filter::serial_in_order,Pos_Finder{pos,pos_genotypes})&
+        tbb::parallel_pipeline(tbb::task_scheduler_init::default_num_threads()*2,tbb::make_filter<void,uint>(tbb::filter::serial_in_order,Pos_Finder{pos,pos_genotypes})&
             tbb::make_filter<uint,std::string*>(tbb::filter::parallel,VCF_Line_Writer{pos_genotypes,chrom_pos_ref[chrom],leaf_count,print_genotypes,chrom})
             &tbb::make_filter<std::string*,void>(tbb::filter::serial_in_order,[&vcf_file](std::string* to_write){
                 if (to_write) {

--- a/src/matUtils/extract.cpp
+++ b/src/matUtils/extract.cpp
@@ -545,10 +545,10 @@ void extract_main (po::parsed_options parsed) {
                 //fprintf(stderr, "DEBUG: writing file %s\n", (std::to_string(counter) + "_context.json").c_str());
                 write_json_from_mat(&subt, batch_samples[s] + "_context.json", &catmeta);
                 // counter++;
-            }
-            fprintf(stderr, "%ld batch sample jsons written in %ld msec.\n\n", batch_samples.size(), timer.Stop());
+            }    
+        }, ap) ; 
+        fprintf(stderr, "%ld batch sample jsons written in %ld msec.\n\n", batch_samples.size(), timer.Stop());
 
-        }) ; 
     }    
     //if json output AND sample context is requested, add an additional metadata column which simply indicates the focal sample versus context
     if ((json_filename != "") && (nearest_k != "")) {

--- a/src/matUtils/extract.cpp
+++ b/src/matUtils/extract.cpp
@@ -525,22 +525,30 @@ void extract_main (po::parsed_options parsed) {
         auto batch_samples = read_sample_names(sample_file);
         timer.Start();
         // size_t counter = 0;
-        for (auto s: batch_samples) {
-            std::map<std::string,std::string> conmap;
-            conmap[s] = "focal";
-            catmeta["focal_view"] = conmap;
-            auto cs = get_nearby(&T, s, nk);
-            MAT::Tree subt = filter_master(T, cs, false);
-            //remove forward slashes from the string, replacing them with underscores.
-            size_t pos = 0;
-            while ((pos = s.find("/")) != std::string::npos) {
-                s.replace(pos, 1, "_");
+        static tbb::affinity_partitioner ap;
+        size_t num_desc = 0;
+
+        tbb::parallel_for(tbb::blocked_range<size_t>(0, batch_samples.size() ),
+                      [&](const tbb::blocked_range<size_t> r) {
+
+           for (int s = r.begin() ; s < r.end() ; ++s ) {
+                std::map<std::string,std::string> conmap;
+                conmap[batch_samples[s]] = "focal";
+                catmeta["focal_view"] = conmap;
+                auto cs = get_nearby(&T, batch_samples[s], nk);
+                MAT::Tree subt = filter_master(T, cs, false);
+                //remove forward slashes from the string, replacing them with underscores.
+                size_t pos = 0;
+                while ((pos = batch_samples[s].find("/")) != std::string::npos) {
+                    batch_samples[s].replace(pos, 1, "_");
+                }
+                //fprintf(stderr, "DEBUG: writing file %s\n", (std::to_string(counter) + "_context.json").c_str());
+                write_json_from_mat(&subt, batch_samples[s] + "_context.json", &catmeta);
+                // counter++;
             }
-            //fprintf(stderr, "DEBUG: writing file %s\n", (std::to_string(counter) + "_context.json").c_str());
-            write_json_from_mat(&subt, s + "_context.json", &catmeta);
-            // counter++;
-        }
-        fprintf(stderr, "%ld batch sample jsons written in %ld msec.\n\n", batch_samples.size(), timer.Stop());
+            fprintf(stderr, "%ld batch sample jsons written in %ld msec.\n\n", batch_samples.size(), timer.Stop());
+
+        }) ; 
     }    
     //if json output AND sample context is requested, add an additional metadata column which simply indicates the focal sample versus context
     if ((json_filename != "") && (nearest_k != "")) {


### PR DESCRIPTION
VCF dump was parallelized with tbb::parallel_pipeline, (the serial_in_order flag make sure pos is sorted), so dumping VCF won't take longer than matOptimize now :).
There is no change to command line interface.

