### PR TITLE
matUtils: parallel minimum subtree extraction using tbb objects for bookkeeping

### DIFF
--- a/src/matUtils/common.hpp
+++ b/src/matUtils/common.hpp
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include <boost/program_options.hpp> 
+#include <boost/program_options.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/iostreams/filtering_streambuf.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
@@ -12,4 +12,4 @@
 
 namespace po = boost::program_options;
 
-extern Timer timer; 
+extern Timer timer;

--- a/src/matUtils/convert.cpp
+++ b/src/matUtils/convert.cpp
@@ -555,26 +555,6 @@ void get_minimum_subtrees(MAT::Tree* T, std::vector<std::string> samples, size_t
     }
     std::vector<size_t> displayed_samples (samples.size(), 0);
 
-/*
-
-Russ pseudocode
-
-1. create a thread-safe map of form <vector<string>> , count
-2. create a thead-safe map of for <string, count>
-
-now check if samples exist in map (2)
-
-if yes, skip it,
-otherwise,
-  record that we have it,
-  get the minimum subtree for that set of samples
-  print that subtree
-
-*/
-
-    /// sample sets that have been seen previously
-//    tbb::concurrent_unordered_map<std::vector<std::string>, int > trees_we_have_seen ;
-
     /// set of all samples that have been seen
     tbb::concurrent_unordered_map<std::string, int > samples_we_have_seen ;
 
@@ -590,11 +570,6 @@ otherwise,
             continue ;
         }
 
-//        if (displayed_samples[i] != 0) {
-            // fprintf(stderr, "%s is displayed in %ld, skipping\n", samples[i].c_str(), displayed_samples[i]);
-//            continue;
-//        }
-
         /// get the nearby tree of size nearest_subtree_size
         std::vector<std::string> leaves_to_keep = get_nearby( T, samples[i], nearest_subtree_size ) ;
 
@@ -608,71 +583,6 @@ otherwise,
 
         auto new_T = Mutation_Annotated_Tree::get_subtree(*T, leaves_to_keep);
 
-
-//        auto check_tree = trees_we_have_seen.find( leaves_to_keep ) ;
-//        if ( check_tree != trees_we_have_seen.end() ) {
-//            continue ;
-//        }
-//        check_tree->second = 1 ;
-//        trees_we_have_seen[ leaves_to_keep ] ++ ;
-
-        /// now insert all samples
-
-/*
-        Mutation_Annotated_Tree::Node* last_anc = T->get_node(samples[i]);
-        std::vector<std::string> leaves_to_keep;
-        for (auto anc: T->rsearch(samples[i], true)) {
-            size_t num_leaves = T->get_num_leaves(anc);
-            if (num_leaves <= nearest_subtree_size) {
-                last_anc = anc;
-                continue;
-            }
-
-            if (num_leaves > nearest_subtree_size) {
-                for (auto l: T->get_leaves(last_anc->identifier)) {
-                    leaves_to_keep.emplace_back(l->identifier);
-                }
-
-                std::vector<Mutation_Annotated_Tree::Node*> siblings;
-                for (auto child: anc->children) {
-                    if (child->identifier != last_anc->identifier) {
-                        siblings.emplace_back(child);
-                    }
-                }
-
-                for (size_t k=0; k<siblings.size(); k++) {
-                    for (auto l: T->get_leaves(siblings[k]->identifier)) {
-                        leaves_to_keep.emplace_back(l->identifier);
-                    }
-                }
-                leaves_to_keep.resize(nearest_subtree_size);
-            } else {
-                for (auto l: T->get_leaves(anc->identifier)) {
-                    leaves_to_keep.emplace_back(l->identifier);
-                }
-            }
-
-*/
-/*
-            auto new_T = Mutation_Annotated_Tree::get_subtree(*T, leaves_to_keep);
-            size_t count_displayed = 1;
-            displayed_samples[i] = num_subtrees;
-//            tbb::parallel_for (tbb::blocked_range<size_t>(i+1, samples.size(), 100),
-//                    [&](tbb::blocked_range<size_t> r) {
-//                    for (size_t j=r.begin(); j<r.end(); ++j){
-                        for (size_t j = i+1; j < samples.size(); j++) {
-                            if (displayed_samples[j] == 0) {
-                                if (new_T.get_node(samples[j]) != NULL) {
-                                    displayed_samples[j] = num_subtrees;
-                                    count_displayed++;
-                                }
-                            }
-                        }
-//                    }
-//                    });
-
-
-*/
             //from here, this function diverges from the similar function in the MAT definition.
             if (json_n != output_dir) {
                 std::string outf = json_n + "-subtree-" + std::to_string(tree_num) + ".json";
@@ -686,16 +596,9 @@ otherwise,
                 subtree_file << newick_ss.rdbuf();
                 subtree_file.close();
             }
-          }
-        /// end TBB loop
-        } ) ;
-/*
-            ++num_subtrees;
-            fprintf(stderr, "Subtree %d identified, containing %ld samples\n", num_subtrees, count_displayed);
-            break;
         }
-    }
-*/
+    /// end TBB loop
+    } ) ;
 
     std::ofstream tracker (output_dir + "subtree-assignments.tsv");
     tracker << "samples";

--- a/src/matUtils/convert.cpp
+++ b/src/matUtils/convert.cpp
@@ -47,7 +47,7 @@ int8_t *new_gt_array(int size, int8_t ref) {
 }
 
 uint r_add_genotypes(MAT::Node *node,
-                     std::unordered_map<std::string, std::vector<int8_t *>> &chrom_pos_genotypes, 
+                     std::unordered_map<std::string, std::vector<int8_t *>> &chrom_pos_genotypes,
                      std::unordered_map<std::string, std::vector<int8_t>> &chrom_pos_ref,
                      uint leaf_count, uint leaf_ix, std::vector<struct MAT::Mutation *> &mut_stack) {
     // Traverse tree, adding leaf/sample genotypes for mutations annotated on path from root to node
@@ -274,7 +274,7 @@ void make_vcf (MAT::Tree T, std::string vcf_filepath, bool no_genotypes) {
         boost::iostreams::filtering_streambuf<boost::iostreams::output> outbuf;
         if (vcf_filepath.find(".gz\0") != std::string::npos) {
             outbuf.push(boost::iostreams::gzip_compressor());
-        } 
+        }
         outbuf.push(outfile);
         std::ostream vcf_file(&outbuf);
         //FILE *vcf_file = fopen(vcf_filepath.c_str(), "w");
@@ -304,7 +304,7 @@ std::string write_mutations(MAT::Node *N) { // writes muts as a list, e.g. "A234
     return muts ;
 }
 
-//the below is more formal JSON parsing code. 
+//the below is more formal JSON parsing code.
 //the goal is to load a nextstrain JSON into a MAT structure
 //which is compatible with various downstream tools.
 
@@ -312,7 +312,7 @@ void create_node_from_json(MAT::Tree* T, json nodeinfo, MAT::Node* parent = NULL
     //this function is recursive.
     //generate and save a node from the parent first
     //then for each child, run this function on them, with this node as the parent.
-    if (nodeinfo.contains("branch_attrs")) {    
+    if (nodeinfo.contains("branch_attrs")) {
         std::string nid;
         if (nodeinfo.contains("name")) {
             nid = nodeinfo["name"];
@@ -322,7 +322,7 @@ void create_node_from_json(MAT::Tree* T, json nodeinfo, MAT::Node* parent = NULL
         }
         MAT::Node* n;
         if (parent != NULL) {
-            n = T->create_node(nid, parent);    
+            n = T->create_node(nid, parent);
         } else {
             n = T->create_node(nid, 0.0, 1);
         }
@@ -341,13 +341,13 @@ void create_node_from_json(MAT::Tree* T, json nodeinfo, MAT::Node* parent = NULL
                 int8_t nucid;
                 if (static_cast<char>(m[0]) == '-') {
                     //the MAT .pb format does NOT support ambiguous parent bases.
-                    //skip these. 
+                    //skip these.
                     //record the number of entries skipped for warning printouts.
                     (*warning_counter)++;
                     continue;
                 } else {
                     nucid = MAT::get_nuc_id(m[0]);
-                    mut.par_nuc = nucid; 
+                    mut.par_nuc = nucid;
                     mut.ref_nuc = nucid; //JSON does not track the original reference vs the parent. We're going to treat the parent as reference.
                 }
                 mut.position = std::stoi(m.substr(1, m.size()-1));
@@ -373,7 +373,7 @@ void create_node_from_json(MAT::Tree* T, json nodeinfo, MAT::Node* parent = NULL
         }
     } else {
         //there are sometimes "nodes" in the json
-        //which do not represent actual samples, or anything, and do not have 
+        //which do not represent actual samples, or anything, and do not have
         //branch_attrs. in these cases, we want to continue with their children
         //treating the parent of this pseudo-node as their parent.
         if (nodeinfo.contains("children")) {
@@ -415,8 +415,8 @@ json get_json_entry(MAT::Node* n, std::vector<std::map<std::string,std::map<std:
         }
     }
     std::map<std::string,std::vector<std::string>> nmap {{"nuc", mutids},};
-    //mutation information is encoded twice in the output we're using. 
-    //don't ask me why. 
+    //mutation information is encoded twice in the output we're using.
+    //don't ask me why.
     std::map<std::string,std::string> mutv {{"nuc mutations", muts}, {"sample",n->identifier}};
     sj["branch_attrs"] = {{"labels",mutv}, {"mutations",nmap}};
     //note: the below is pretty much sars-cov-2 specific. but so is all json-related things.
@@ -454,7 +454,7 @@ json get_json_entry(MAT::Node* n, std::vector<std::map<std::string,std::map<std:
     for (const auto& cmet: *catmeta) {
         for (const auto& cmi: cmet) {
             if (cmi.second.find(n->identifier) != cmi.second.end()) {
-                //store the metadata on both the branch and the tip for now. 
+                //store the metadata on both the branch and the tip for now.
                 sj["branch_attrs"]["labels"][cmi.first] = cmi.second.at(n->identifier);
                 sj["node_attrs"][cmi.first]["value"] = cmi.second.at(n->identifier);
             }
@@ -495,15 +495,15 @@ void write_json_from_mat(MAT::Tree* T, std::string output_filename, std::vector<
                 if (cmi.first.find("continuous") != std::string::npos) {
                     //if the substring "continuous" is found in the metadata column name, attempt to interpet the values accordingly.
                     std::map<std::string,std::string> mmap {{"key",cmi.first},{"title",cmi.first},{"type","continuous"}};
-                    nj["meta"]["colorings"].push_back(mmap);                      
+                    nj["meta"]["colorings"].push_back(mmap);
                 } else {
                     std::map<std::string,std::string> mmap {{"key",cmi.first},{"title",cmi.first},{"type","categorical"}};
-                    nj["meta"]["colorings"].push_back(mmap);         
-                }   
+                    nj["meta"]["colorings"].push_back(mmap);
+                }
             }
         }
     }
-    //check whether each of the mat clade annotation fields are used by any sample. 
+    //check whether each of the mat clade annotation fields are used by any sample.
     bool uses_clade_0 = false;
     bool uses_clade_1 = false;
     for (auto n: T->depth_first_expansion()) {
@@ -554,12 +554,71 @@ void get_minimum_subtrees(MAT::Tree* T, std::vector<std::string> samples, size_t
         catmeta->emplace_back(csqm);
     }
     std::vector<size_t> displayed_samples (samples.size(), 0);
-    int num_subtrees = 1;
-    for (size_t i = 0; i < samples.size(); i++) {
-        if (displayed_samples[i] != 0) {
-            // fprintf(stderr, "%s is displayed in %ld, skipping\n", samples[i].c_str(), displayed_samples[i]);
-            continue;
+
+/*
+
+Russ pseudocode
+
+1. create a thread-safe map of form <vector<string>> , count
+2. create a thead-safe map of for <string, count>
+
+now check if samples exist in map (2)
+
+if yes, skip it,
+otherwise,
+  record that we have it,
+  get the minimum subtree for that set of samples
+  print that subtree
+
+*/
+
+    /// sample sets that have been seen previously
+//    tbb::concurrent_unordered_map<std::vector<std::string>, int > trees_we_have_seen ;
+
+    /// set of all samples that have been seen
+    tbb::concurrent_unordered_map<std::string, int > samples_we_have_seen ;
+
+    /// record the subtree number_to_get
+    tbb::atomic<int> num_subtrees = 0 ;
+
+    tbb::parallel_for (tbb::blocked_range<size_t>(1, samples.size()),
+            [&](tbb::blocked_range<size_t> r) {
+    for (size_t i = r.begin(); i < r.end() ; i++) {
+
+        auto check_sample = samples_we_have_seen.find( samples[i] ) ;
+        if ( check_sample != samples_we_have_seen.end() ) {
+            continue ;
         }
+
+//        if (displayed_samples[i] != 0) {
+            // fprintf(stderr, "%s is displayed in %ld, skipping\n", samples[i].c_str(), displayed_samples[i]);
+//            continue;
+//        }
+
+        /// get the nearby tree of size nearest_subtree_size
+        std::vector<std::string> leaves_to_keep = get_nearby( T, samples[i], nearest_subtree_size ) ;
+
+        /// increment number of subtrees
+        //num_subtrees ++ ;
+        int tree_num = ++ num_subtrees ;
+        /// now record all samples in this specific subtree
+        for ( int s = 0 ; s < leaves_to_keep.size() ; s ++ ) {
+            samples_we_have_seen.insert({leaves_to_keep[s],tree_num}) ;
+        }
+
+        auto new_T = Mutation_Annotated_Tree::get_subtree(*T, leaves_to_keep);
+
+
+//        auto check_tree = trees_we_have_seen.find( leaves_to_keep ) ;
+//        if ( check_tree != trees_we_have_seen.end() ) {
+//            continue ;
+//        }
+//        check_tree->second = 1 ;
+//        trees_we_have_seen[ leaves_to_keep ] ++ ;
+
+        /// now insert all samples
+
+/*
         Mutation_Annotated_Tree::Node* last_anc = T->get_node(samples[i]);
         std::vector<std::string> leaves_to_keep;
         for (auto anc: T->rsearch(samples[i], true)) {
@@ -592,6 +651,9 @@ void get_minimum_subtrees(MAT::Tree* T, std::vector<std::string> samples, size_t
                     leaves_to_keep.emplace_back(l->identifier);
                 }
             }
+
+*/
+/*
             auto new_T = Mutation_Annotated_Tree::get_subtree(*T, leaves_to_keep);
             size_t count_displayed = 1;
             displayed_samples[i] = num_subtrees;
@@ -608,24 +670,33 @@ void get_minimum_subtrees(MAT::Tree* T, std::vector<std::string> samples, size_t
                         }
 //                    }
 //                    });
+
+
+*/
             //from here, this function diverges from the similar function in the MAT definition.
             if (json_n != output_dir) {
-                std::string outf = json_n + "-subtree-" + std::to_string(num_subtrees) + ".json";
+                std::string outf = json_n + "-subtree-" + std::to_string(tree_num) + ".json";
                 write_json_from_mat(&new_T, outf, catmeta);
             }
             if (newick_n != output_dir) {
-                std::string outf = newick_n + "-subtree-" + std::to_string(num_subtrees) + ".nw";
+                std::string outf = newick_n + "-subtree-" + std::to_string(tree_num) + ".nw";
                 std::ofstream subtree_file(outf.c_str(), std::ofstream::out);
                 std::stringstream newick_ss;
                 write_newick_string(newick_ss, new_T, new_T.root, true, true, retain_original_branch_len);
-                subtree_file << newick_ss.rdbuf(); 
+                subtree_file << newick_ss.rdbuf();
                 subtree_file.close();
             }
+          }
+        /// end TBB loop
+        } ) ;
+/*
             ++num_subtrees;
             fprintf(stderr, "Subtree %d identified, containing %ld samples\n", num_subtrees, count_displayed);
             break;
         }
     }
+*/
+
     std::ofstream tracker (output_dir + "subtree-assignments.tsv");
     tracker << "samples";
     if (json_n != output_dir) {
@@ -638,11 +709,11 @@ void get_minimum_subtrees(MAT::Tree* T, std::vector<std::string> samples, size_t
     for (size_t i = 0; i < samples.size(); i++) {
         tracker << samples[i];
         if (json_n != output_dir) {
-            std::string outf = json_n + "-subtree-" + std::to_string(displayed_samples[i]) + ".json";
-            tracker << "\t" << outf;            
+            std::string outf = json_n + "-subtree-" + std::to_string(samples_we_have_seen[samples[i]]) + ".json";
+            tracker << "\t" << outf;
         }
         if (newick_n != output_dir) {
-            std::string outf = newick_n + "-subtree-" + std::to_string(displayed_samples[i]) + ".nw";
+            std::string outf = newick_n + "-subtree-" + std::to_string(samples_we_have_seen[samples[i]]) + ".nw";
             tracker << "\t" << outf;
         }
         tracker << "\n";

--- a/src/matUtils/convert.hpp
+++ b/src/matUtils/convert.hpp
@@ -4,3 +4,4 @@ void make_vcf (MAT::Tree T, std::string vcf_filename, bool no_genotypes);
 void write_json_from_mat(MAT::Tree* T, std::string output_filename, std::vector<std::map<std::string,std::map<std::string,std::string>>>* catmeta);
 MAT::Tree load_mat_from_json(std::string json_filename);
 void get_minimum_subtrees(MAT::Tree* T, std::vector<std::string> samples, size_t target_size, std::string output_dir, std::vector<std::map<std::string,std::map<std::string,std::string>>>* catmeta, std::string json_n, std::string newick_n, bool retain_original_branch_len = false);
+std::vector<std::string> get_nearby (MAT::Tree* T, std::string sample_id, int number_to_get);

--- a/src/matUtils/select.cpp
+++ b/src/matUtils/select.cpp
@@ -10,7 +10,7 @@ std::vector<std::string> read_sample_names (std::string sample_filename) {
     if (!infile) {
         fprintf(stderr, "ERROR: Could not open the file: %s!\n", sample_filename.c_str());
         exit(1);
-    }    
+    }
     std::string line;
     bool warned = false;
     while (std::getline(infile, line)) {
@@ -20,7 +20,7 @@ std::vector<std::string> read_sample_names (std::string sample_filename) {
             fprintf(stderr, "WARNING: Input file %s contains excess columns; ignoring\n", sample_filename.c_str());
             warned = true;
         }
-        //remove carriage returns from the input to handle windows os 
+        //remove carriage returns from the input to handle windows os
         auto sname = words[0];
         if (sname[sname.size()-1] == '\r') {
             sname = sname.substr(0,sname.size()-1);
@@ -49,7 +49,7 @@ std::vector<std::string> get_clade_samples (MAT::Tree* T, std::string clade_name
                         //this is the root of the input clade (first one encountered in tree)
                         //get the set of samples descended from this clade root
                         csamples = T->get_leaves_ids(s->identifier);
-                        //and break out by returning 
+                        //and break out by returning
                         return csamples;
                     }
                 }
@@ -67,14 +67,14 @@ std::vector<std::string> get_mutation_samples (MAT::Tree* T, std::string mutatio
 
     for (auto node: T->get_leaves()) {
         bool assigned = false;
-        //first, check if this specific sample has the mutation 
+        //first, check if this specific sample has the mutation
         for (auto m: node->mutations) {
             if (m.get_string() == mutation_id) {
                 good_samples.push_back(node->identifier);
                 assigned = true;
                 break;
             }
-        } 
+        }
         if (!assigned) {
             std::vector<MAT::Node*> path = T->rsearch(node->identifier);
             //for every ancestor up to the root, check if they have the mutation
@@ -85,7 +85,7 @@ std::vector<std::string> get_mutation_samples (MAT::Tree* T, std::string mutatio
                         if (m.get_string() == mutation_id) {
                             good_samples.push_back(node->identifier);
                             assigned = true;
-                            break;     
+                            break;
                         }
                     }
                 } else {
@@ -113,7 +113,7 @@ std::vector<std::string> get_parsimony_samples (MAT::Tree* T, int max_parsimony)
 std::vector<std::string> get_clade_representatives(MAT::Tree* T) {
     timer.Start();
     fprintf(stderr, "Selecting clade representative samples...");
-    //get a pair of representative leaves for every clade currently annotated in the tree 
+    //get a pair of representative leaves for every clade currently annotated in the tree
     //and return as a vector of samples
     //specifically, the leaves LCA must be the clade root node
     //to accomplish this, first identify the clade root,
@@ -124,7 +124,7 @@ std::vector<std::string> get_clade_representatives(MAT::Tree* T) {
     std::vector<std::string> rep_samples;
     //expand and identify clades seen
     std::unordered_set<std::string> clades_seen;
-    
+
     auto dfs = T->breadth_first_expansion();
     for (auto n: dfs) {
         std::string curpath;
@@ -156,7 +156,7 @@ std::vector<std::string> get_clade_representatives(MAT::Tree* T) {
                         }
                     }
                     //there may be cases where a clade iterates all the way through and every sample which could represent it is already
-                    //selected by some other clade, but in that case its perfectly represented anyways, so theres no reason to get more 
+                    //selected by some other clade, but in that case its perfectly represented anyways, so theres no reason to get more
                     //samples just for it
                 }
             }
@@ -287,7 +287,7 @@ std::vector<std::string> get_short_steppers(MAT::Tree* T, std::vector<std::strin
         }
         if (!badanc) {
             good_samples.push_back(s);
-        } 
+        }
     }
     return good_samples;
 }
@@ -297,7 +297,7 @@ std::map<std::string,std::map<std::string,std::string>> read_metafile(std::strin
     if (!infile) {
         fprintf(stderr, "ERROR: Could not open the file: %s!\n", metainf.c_str());
         exit(1);
-    }    
+    }
     std::string line;
     bool first = true;
     char delim = '\t';
@@ -323,9 +323,9 @@ std::map<std::string,std::map<std::string,std::string>> read_metafile(std::strin
         } else {
             for (size_t i=1; i < words.size(); i++) {
                 //std::cerr << words[i];
-                if (samples_to_use.find(words[0]) != samples_to_use.end()) {
+//                if (samples_to_use.find(words[0]) != samples_to_use.end()) {
                     metamap[keys[i]][words[0]] = words[i];
-                }
+//                }
             }
         }
     }
@@ -347,7 +347,7 @@ std::vector<std::string> get_sample_match(MAT::Tree* T, std::string substring) {
 }
 
 std::vector<std::string> fill_random_samples(MAT::Tree* T, std::vector<std::string> current_samples, size_t target_size) {
-    //expand the current sample selection with random samples until it is the indicated size. 
+    //expand the current sample selection with random samples until it is the indicated size.
     //alternatively, prune random samples from the selection until it is the indicated size, as necessary.
     std::set<std::string> choices;
     fprintf(stderr, "Selected sample set is %ld samples with %ld requested subtree size; ", current_samples.size(), target_size);
@@ -381,4 +381,4 @@ std::vector<std::string> fill_random_samples(MAT::Tree* T, std::vector<std::stri
     std::vector<std::string> filled_samples (choices.begin(), choices.end());
     assert (filled_samples.size() == target_size);
     return filled_samples;
-}  
+}


### PR DESCRIPTION
This is a PR that includes a way to do parallel subtree extraction (via -N). The idea is to use tbb objects for threadsafe bookkeeping of what we have already seen in previous subtrees and to structure the bookkeeping in a more intuitive way. Most of what is new is in convert.cpp (see also the needed get_nearby() predeclaration in convert.hpp). I suspect the same basic logic could improve the existing minimum subtree extraction when tons of samples are specified. 

@jmcbroome it would be wise to make sure I did not break any of the intended usage of this function. Also @yatisht, it is worth taking a look at how I did this since I am relatively new to tbb. I suspect there are ways to improve. 

This PR also removed the "selected samples only" metadata extraction for jsons since we may want to provide such metadata for context samples. 

An example command line is 

matUtils -i <pb> -s <sample_set> -M <metadata> -d <ouput_dir> -j <tree_filename_base> 

This will create the minimum set of subtrees in output_dir with a final tsv file that maps sample names onto subtree files. The map file also appears in output_dir. 

