### PR TITLE
Use the new option to keep clade annotations for extract -r.

### DIFF
--- a/src/matUtils/extract.cpp
+++ b/src/matUtils/extract.cpp
@@ -420,7 +420,7 @@ void extract_main (po::parsed_options parsed) {
         //fprintf(stderr, "Filtering again to a clade representative tree...\n");
         auto rep_samples = get_clade_representatives(&subtree);
         //run filter master again
-        subtree = filter_master(subtree, rep_samples, false);
+        subtree = filter_master(subtree, rep_samples, false, true);
         //overwrite samples with new subset
         samples = rep_samples;
     }


### PR DESCRIPTION
This is just making use of the new filter_master option to keep clade annotations when the matUtils extract -r/--get_representative option is used, since matUtils extract -r is for use with clade annotations.
