### PR TITLE
skip missing samples

### DIFF
--- a/src/matUtils/convert.cpp
+++ b/src/matUtils/convert.cpp
@@ -571,6 +571,11 @@ void get_minimum_subtrees(MAT::Tree* T, std::vector<std::string> samples, size_t
           /// get the nearby tree of size nearest_subtree_size
           std::vector<std::string> leaves_to_keep = get_nearby( T, samples[i], nearest_subtree_size ) ;
 
+          if ( leaves_to_keep.size() == 0 ) {
+              samples_we_have_seen.insert({samples[i],-1}) ; 
+              continue ;
+          }
+
           /// record all samples seen
           for ( int s = 0 ; s < leaves_to_keep.size() ; s ++ ) {
               samples_we_have_seen.insert({leaves_to_keep[s],subtree_sample_sets.size()}) ;
@@ -613,6 +618,9 @@ void get_minimum_subtrees(MAT::Tree* T, std::vector<std::string> samples, size_t
     }
     tracker << "\n";
     for (size_t i = 0; i < samples.size(); i++) {
+        if ( samples_we_have_seen[samples[i]] == -1 ) {
+            continue ;
+        }
         tracker << samples[i];
         if (json_n != output_dir) {
             std::string outf = json_n + "-subtree-" + std::to_string(samples_we_have_seen[samples[i]]) + ".json";

--- a/src/matUtils/select.cpp
+++ b/src/matUtils/select.cpp
@@ -187,7 +187,7 @@ std::vector<std::string> get_nearby (MAT::Tree* T, std::string sample_id, int nu
     //unfortunately. so we have to brute force it.
     MAT::Node* last_anc = T->get_node(sample_id);
     if (last_anc == NULL) {
-        fprintf(stderr, "ERROR: Indicated sample does not exist in the tree!\n");
+        fprintf(stderr, "ERROR: %s is not present in the tree!\n", sample_id.c_str() );
     }
     std::vector<std::string> leaves_to_keep;
     for (auto anc: T->rsearch(sample_id, true)) {
@@ -224,7 +224,7 @@ std::vector<std::string> get_nearby (MAT::Tree* T, std::string sample_id, int nu
             break;
         }
     }
-    assert (leaves_to_keep.size() == static_cast<size_t>(number_to_get));
+    //assert (leaves_to_keep.size() == static_cast<size_t>(number_to_get));
     return leaves_to_keep;
 }
     //by far the simplest way to do this is to get_leaves_ids and subset out a distance around the index


### PR DESCRIPTION
This PR should skip missing samples passed to select.cpp:get_nearby(). The previous version would choke on the assert(), but in batch mode this can be very annoying. It now prints an error and all calls check if the returned vector is empty and continue. 

