### PR TITLE
matUtils extract --get-representative: number of samples per clade

### DIFF
--- a/src/matUtils/select.hpp
+++ b/src/matUtils/select.hpp
@@ -5,7 +5,7 @@ std::vector<std::string> read_sample_names (std::string sample_filename);
 std::vector<std::string> get_clade_samples (MAT::Tree* T, std::string clade_name);
 std::vector<std::string> get_mutation_samples (MAT::Tree* T, std::string mutation_id);
 std::vector<std::string> get_parsimony_samples (MAT::Tree* T, int max_parsimony);
-std::vector<std::string> get_clade_representatives(MAT::Tree* T);
+std::vector<std::string> get_clade_representatives(MAT::Tree* T, size_t samples_per_clade);
 std::vector<std::string> sample_intersect (std::vector<std::string> samples, std::vector<std::string> nsamples);
 std::vector<std::string> get_nearby (MAT::Tree* T, std::string sample_id, int number_to_get);
 std::vector<std::string> get_short_steppers(MAT::Tree* T, std::vector<std::string> samples_to_check, int max_mutations);


### PR DESCRIPTION
Make --get-representative take an int value, the number of leaves to keep per clade (min 2).  Randomly select leaves for each clade.  This allows us to keep more than the bare minimum of samples per clade, while still pruning most of the tree.

Note: the random selection of samples can have a significant effect on the accuracy of placements on the derived tree.  There is probably a better way to select representative samples than randomness.  In the meantime, when using this, I have been extracting multiple random subtrees, testing their accuracy in lineage assignment, and selecting the best one for use with pangolin --usher.