### PR TITLE
New matUtils annotate option --clade-paths <filename>

### DIFF
--- a/src/matUtils/annotate.hpp
+++ b/src/matUtils/annotate.hpp
@@ -4,3 +4,4 @@ po::variables_map parse_annotate_command(po::parsed_options parsed);
 void annotate_main(po::parsed_options parsed);
 void assignLineages (MAT::Tree& T, const std::string& lineage_filename, bool clear_current = false);
 void assignLineages (MAT::Tree& T, const std::string& lineage_filename, float min_freq, float mask_freq, float set_overlap, float clip_sample_frequency, bool clear_current = false, const std::string& mutations_filename = "", const std::string& details_filename = "");
+void assignLineagesFromPaths (MAT::Tree& T, const std::string& clade_paths_filename, bool clear_current = false);

--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -484,6 +484,10 @@ Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::load_mutation_annotated_t
         stat(filename.c_str(),&stat_buf);
         size_t file_size=stat_buf.st_size;
         auto fd=open(filename.c_str(), O_RDONLY);
+        if (fd < 0) {
+            fprintf(stderr, "ERROR: can't open file %s\n", filename.c_str());
+            exit(1);
+        }
         uint8_t* maped_file=(uint8_t*)mmap(nullptr, file_size, PROT_READ, MAP_SHARED,fd , 0);
         close(fd);
         google::protobuf::io::CodedInputStream input(maped_file,file_size);


### PR DESCRIPTION
This adds a third method of assigning clades to nodes: a TSV input file with clade name and mutation path, like the first and third columns of output from matUtils extract --clade-paths (and no header line).  Each mutation path is followed from root by finding a child node with the exact same set of mutations as each element in the path.  If the terminal node in the path is found, then the clade is annotated at that node; otherwise, matUtils exits with an error; someone will have to look at the path and the tree and determine how the path needs to be updated.  I have tested on the 2021-07-13 UCSC tree and some small trees recently created using matUtils extract --get-representatives 50 for the pangolin lineageTree.  I hope that this will support manual tweaks to nodes/paths found by matUtils annotate --clade-names, yet be reusable despite node names that change from one day to the next which is an issue for --clade-to-nid.