### PR TITLE
Missing clade annotations: don't segv; report in matUtils summary --aberrant

### DIFF
--- a/src/matUtils/filter.cpp
+++ b/src/matUtils/filter.cpp
@@ -61,9 +61,6 @@ MAT::Tree get_sample_prune (const MAT::Tree& T, std::vector<std::string> sample_
     auto subtree = MAT::get_tree_copy(T);
     auto dfs = T.depth_first_expansion();
     for (auto s: dfs) {
-        if (!keep_clade_annotations) {
-            s->clear_annotations();
-        }
         //only call the remover on leaf nodes (can't be deleting the root...)
         if (s->is_leaf()) {
             //if the node is NOT in the set, remove it
@@ -75,6 +72,12 @@ MAT::Tree get_sample_prune (const MAT::Tree& T, std::vector<std::string> sample_
             }
         }
     }    
+    if (!keep_clade_annotations) {
+        dfs = subtree.depth_first_expansion();
+        for (auto s: dfs) {
+            s->clear_annotations();
+        }
+    }
     fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
     return subtree;
 }

--- a/src/matUtils/summary.cpp
+++ b/src/matUtils/summary.cpp
@@ -415,6 +415,7 @@ void summary_main(po::parsed_options parsed) {
         fprintf(stdout, "Total Condensed Nodes in Tree: %ld\n", num_condensed_nodes);
         fprintf(stdout, "Total Samples in Condensed Nodes: %ld\n", num_condensed_leaves);
         fprintf(stdout, "Total Tree Parsimony: %ld\n", T.get_parsimony_score());
+        fprintf(stdout, "Number of Clade Annotations: %ld\n", T.get_num_annotations());
         fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
     }
 }

--- a/src/matUtils/summary.cpp
+++ b/src/matUtils/summary.cpp
@@ -154,6 +154,7 @@ void write_aberrant_table(MAT::Tree& T, std::string filename) {
     std::ofstream badfile;
     badfile.open(filename);
     badfile << "NodeID\tIssue\n";
+    size_t num_annotations = T.get_num_annotations();
     std::set<std::string> dup_tracker;
     auto dfs = T.depth_first_expansion();
     for (auto n: dfs) {
@@ -164,6 +165,10 @@ void write_aberrant_table(MAT::Tree& T, std::string filename) {
         }
         if (n->mutations.size() == 0 && !n->is_leaf() && !n->is_root()) {
             badfile << n->identifier << "\tinternal-no-mutations\n";
+        }
+        if (num_annotations != n->clade_annotations.size()) {
+            badfile << n->identifier << "\tclade-annotations (" << n->clade_annotations.size() <<
+              " not " << num_annotations << ")\n";
         }
     }
 }

--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -876,7 +876,7 @@ std::vector<Mutation_Annotated_Tree::Node*> Mutation_Annotated_Tree::Tree::rsear
 std::string Mutation_Annotated_Tree::Tree::get_clade_assignment (const Node* n, int clade_id, bool include_self) const {
     assert ((size_t)clade_id < get_num_annotations());
     for (auto anc: rsearch(n->identifier, include_self)) {
-        if (anc->clade_annotations[clade_id] != "") {
+      if ((int)anc->clade_annotations.size() > clade_id && anc->clade_annotations[clade_id] != "") {
             return anc->clade_annotations[clade_id];
         }
     }


### PR DESCRIPTION
Recently a protobuf from the new matOptimize had some nodes with 0 clade_annotations while the tree was supposed to have 2 annotations (and most nodes did have 2).  This caused a segv in usher when assigning clades because it assumed that all nodes would have the same number of clade_annotations.

Feel free to reject if you would rather exit with an error instead, but this branch includes a change to get_clade_assignment in mutation_annotated_tree.cpp to silently treat a node with fewer annotations than expected as if it were simply unannotated (empty string for annotations) instead of getting a segv.

I also added a new item to the matUtils summary --aberrant report, for nodes with the wrong number of clade_annotations.  That could be useful for testing while adding new features that change the tree.