### PR TITLE
matUtils mask --rename: check for duplicate names

### DIFF
--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -730,6 +730,10 @@ size_t Mutation_Annotated_Tree::Tree::get_num_annotations () const {
 void Mutation_Annotated_Tree::Tree::rename_node(std::string old_nid, std::string new_nid) {
     auto n = get_node(old_nid);
     if (n != NULL) {
+        if (all_nodes.find(new_nid) != all_nodes.end()) {
+            fprintf(stderr, "ERROR: rename_node: node with id '%s' already exists.\n", new_nid.c_str());
+            exit(1);
+        }
         n->identifier = new_nid;
         all_nodes.erase(old_nid);
         all_nodes[new_nid] = n;


### PR DESCRIPTION
When updating names with matUtils mask --rename, occasionally I've been bitten by a sequence being in the tree with both old and new name.  Then, renaming the old name to the new name means that there are two samples in the tree with the same (new) name.  That didn't cause any error for matUtils mask --rename, but the resulting protobuf would get an error when loading it with matUtils summary or other programs.

This change causes matUtils mask --rename to exit with an error if the new name is already in the tree.