### PR TITLE
Simplify matUtils extract --clade-paths (and allow multiple paths for an annotated clade)

### DIFF
--- a/src/matUtils/describe.cpp
+++ b/src/matUtils/describe.cpp
@@ -25,49 +25,40 @@ std::vector<std::string> mutation_paths(const MAT::Tree& T, std::vector<std::str
     return mpaths;
 }
 
-std::vector<std::string> clade_paths(MAT::Tree T, std::vector<std::string> clades) {
+std::vector<std::string> clade_paths(MAT::Tree T) {
     //get the set of clade path strings for printing
     //similar to the above, construct a series of strings to be printed or redirected later on
     std::vector<std::string> clpaths;
     clpaths.push_back("clade\troot_id\tfrom_tree_root\n");
     //do a breadth-first search
-    //the first time a clade that is in clades is encountered, that's the root;
-    //get the path of mutations to that root (rsearch), save the unique mutations + that path
-    //unique mutations being ones that occurred in the clade root, and the path being all mutations from that root back to the tree root
-    //then continue. if a clade has already been encountered in the breadth first, its
-    //not clade root, and should be skipped.
-    std::set<std::string> clades_seen;
+    //clades are annotated only at the root, so when we see an annotation, add it to the list.
 
-    auto dfs = T.breadth_first_expansion();
-    for (auto n: dfs) {
+    auto bfs = T.breadth_first_expansion();
+    for (auto n: bfs) {
         for (auto ann: n->clade_annotations) {
             if (ann != "") {
                 std::string curpath;
-                //if its one of our target clades and it hasn't been seen...
-                if (std::find(clades.begin(), clades.end(), ann) != clades.end() && clades_seen.find(ann) == clades_seen.end()) {
-                    //record the name of the clade
-                    curpath += ann + "\t";
-                    curpath += n->identifier + "\t";
-                    //get the ancestral mutations back to the root
-                    std::string root = "";
-                    auto root_to_sample = T.rsearch(n->identifier, true);
-                    std::reverse(root_to_sample.begin(), root_to_sample.end());
-                    for (auto an: root_to_sample) {
-                        for (size_t i=0; i<an->mutations.size(); i++) {
-                            root += an->mutations[i].get_string();
-                            if (i+1 < an->mutations.size()) {
-                                root += ",";
-                            }
-                        }
-                        if (an != root_to_sample.back()) {
-                            root += " > ";
-                        }
-                    }
-                    //save values to the string, mark the clade as seen, and save the string
-                    curpath += root;
-                    clades_seen.insert(ann);
-                    clpaths.push_back(curpath + "\n");
+                //record the name of the clade
+                curpath += ann + "\t";
+                curpath += n->identifier + "\t";
+                //get the ancestral mutations back to the root
+                std::string root = "";
+                auto root_to_sample = T.rsearch(n->identifier, true);
+                std::reverse(root_to_sample.begin(), root_to_sample.end());
+                for (auto an: root_to_sample) {
+                  for (size_t i=0; i<an->mutations.size(); i++) {
+                      root += an->mutations[i].get_string();
+                      if (i+1 < an->mutations.size()) {
+                          root += ",";
+                      }
+                  }
+                  if (an != root_to_sample.back()) {
+                      root += " > ";
+                  }
                 }
+                //save values to the string and save the string
+                curpath += root;
+                clpaths.push_back(curpath + "\n");
             }
         }
     }

--- a/src/matUtils/describe.hpp
+++ b/src/matUtils/describe.hpp
@@ -1,5 +1,5 @@
 #include "common.hpp"
 
 std::vector<std::string> mutation_paths(const MAT::Tree& T, std::vector<std::string> samples);
-std::vector<std::string> clade_paths(MAT::Tree T, std::vector<std::string> clades);
+std::vector<std::string> clade_paths(MAT::Tree T);
 std::vector<std::string> all_nodes_paths(MAT::Tree T);

--- a/src/matUtils/extract.cpp
+++ b/src/matUtils/extract.cpp
@@ -465,29 +465,8 @@ void extract_main (po::parsed_options parsed) {
         fprintf(stderr, "Completed in %ld msec\n\n", timer.Stop());
     }
     if (clade_path_filename != dir_prefix) {
-        //need to get the set of all clade annotations currently in the tree for the clade_paths function
-        //TODO: refactor summary so I can just import the clade counter function from there (disentangle from file printing)
-        //also this block of code just generally sucks.
-        fprintf(stderr, "Writing clade root path strings...\n");
-        timer.Start();
-        std::vector<std::string> cladenames;
-        auto dfs = T.depth_first_expansion();
-        for (auto s: dfs) {
-            std::vector<std::string> canns = s->clade_annotations;
-            if (canns.size() > 0) {
-                if (canns.size() > 1 || canns[0] != "") {
-                    for (auto c: canns) {
-                        if (c != "" && std::find(cladenames.begin(), cladenames.end(), c) == cladenames.end()) {
-                            cladenames.push_back(c);
-                        }
-                    }
-                }
-            }
-        }
         std::ofstream outfile (clade_path_filename);
-        //TODO: maybe better to update clade_paths to take an "all current clades" option.
-        //should be more computationally efficient at least.
-        auto cpaths = clade_paths(T, cladenames);
+        auto cpaths = clade_paths(T);
         for (auto cstr: cpaths) {
             outfile << cstr;
         }


### PR DESCRIPTION
matUtils extract --clade-paths was gathering a list of all clades annotated in the tree and passing that list to clade_paths which then checked each annotation to see whether it was in the list -- unnecessary.  clade_paths was also checking each annotation to see whether that clade annotation had already been encountered, which would be necessary if clades were annotated on all nodes.  However, clades are annotated only at clade root nodes, so that checking is unnecessary.  

[My real reason for making these changes is that if a clade is annotated on multiple branches, then I want each of those annotations to appear in the output, not only the first one encountered.  When there are non-monophylogeny problems with the tree due to either construction methods or unmasked problematic sites, for pangolin --usher it is sometimes necessary to manually annotate a clade on multiple nodes using matUtils annotate --clade-to-nid or --clade-paths.]