### PR TITLE
Add compareVCF and rename_fasta to if(DEFINED Protobuf_PATH) clause of CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,14 @@ if(DEFINED Protobuf_PATH)
         ${DETAILED_MUTATIONS_PROTO_HDRS}
         )
 
+    add_executable(compareVCF
+        src/mutation_annotated_tree.cpp
+        src/compareVCF.cpp)
+
+    add_executable(rename_fasta
+        src/mutation_annotated_tree.cpp
+        src/matOptimize/rename_fasta.cpp)
+
     protobuf_generate(
         LANGUAGE cpp
         TARGET usher 


### PR DESCRIPTION
A couple targets were added to an else() clause but not the if(DEFINED Protobuf_PATH) clause, and then referenced below which caused an error when -DProtobuf_PATH was used as in installCentOS.sh.  This adds the targets so that -DProtobuf_PATH works again.