### PR TITLE
Fix gcc4 build

### DIFF
--- a/src/matOptimize/mutation_annotated_tree.hpp
+++ b/src/matOptimize/mutation_annotated_tree.hpp
@@ -481,11 +481,5 @@ namespace Mutation_Annotated_Tree {
 }
 bool check_grand_parent(const Mutation_Annotated_Tree::Node* node,const Mutation_Annotated_Tree::Node* grand_parent);
 
-template<>
-struct std::hash<Mutation_Annotated_Tree::Mutation> {
-    size_t operator()(const Mutation_Annotated_Tree::Mutation &in) const {
-        return in.get_position();
-    }
-};
 nuc_one_hot get_parent_state(Mutation_Annotated_Tree::Node* ancestor,int position);
 #endif

--- a/src/matOptimize/stack_allocator.hpp
+++ b/src/matOptimize/stack_allocator.hpp
@@ -23,7 +23,7 @@ template<typename T>
         }
         };
 template<typename T>
-struct stack_allocator:private std::allocator<T>{
+struct stack_allocator{
     typedef T value_type;
     typedef T* pointer;
     typedef const T* const_pointer;


### PR DESCRIPTION
It seems GCC 4 just checked a few things more carefully, we probably don't need to update GCC.