### PR TITLE
Updates to Introduce- new option and QC

### DIFF
--- a/src/matUtils/introduce.cpp
+++ b/src/matUtils/introduce.cpp
@@ -684,11 +684,11 @@ std::vector<std::string> find_introductions(MAT::Tree* T, std::map<std::string, 
                 fprintf(stderr, "WARNING: Cluster %s has no valid dates included among samples\n", cs.first.c_str());
                 ldatestr = "no-valid-date\tno-valid-date";
             } else {
-                ldatestr = boost::gregorian::to_simple_string(ldates.first) + "\t" + boost::gregorian::to_simple_string(ldates.second);
-                diff = (ldates.second - ldates.first);
                 if (recency_filter > ldates.second) {
                     continue;
                 }
+                ldatestr = boost::gregorian::to_simple_string(ldates.first) + "\t" + boost::gregorian::to_simple_string(ldates.second);
+                diff = (ldates.second - ldates.first);
             }
             date_tracker[cs.first] = ldatestr;
             float gv;

--- a/src/matUtils/introduce.cpp
+++ b/src/matUtils/introduce.cpp
@@ -686,9 +686,9 @@ std::vector<std::string> find_introductions(MAT::Tree* T, std::map<std::string, 
             } else {
                 ldatestr = boost::gregorian::to_simple_string(ldates.first) + "\t" + boost::gregorian::to_simple_string(ldates.second);
                 diff = (ldates.second - ldates.first);
-            }
-            if (recency_filter > ldates.second) {
-                continue;
+                if (recency_filter > ldates.second) {
+                    continue;
+                }
             }
             date_tracker[cs.first] = ldatestr;
             float gv;

--- a/src/matUtils/introduce.cpp
+++ b/src/matUtils/introduce.cpp
@@ -10,9 +10,9 @@ po::variables_map parse_introduce_command(po::parsed_options parsed) {
     po::options_description filt_desc("introduce options");
     filt_desc.add_options()
     ("input-mat,i", po::value<std::string>()->required(),
-        "Input mutation-annotated tree file [REQUIRED]")
+    "Input mutation-annotated tree file [REQUIRED]")
     ("population-samples,s", po::value<std::string>()->required(), 
-        "Names of samples from the population of interest [REQUIRED].") 
+    "Names of samples from the population of interest [REQUIRED].") 
     ("additional-info,a", po::bool_switch(),
     "Set to calculate additional phylogenetic trait association statistics for whole regions and individual introductions. WARNING: Adds significantly to runtime.")
     ("clade-regions,c", po::value<std::string>()->default_value(""),

--- a/src/matUtils/introduce.cpp
+++ b/src/matUtils/introduce.cpp
@@ -9,51 +9,28 @@ po::variables_map parse_introduce_command(po::parsed_options parsed) {
     po::variables_map vm;
     po::options_description filt_desc("introduce options");
     filt_desc.add_options()
-<<<<<<< HEAD
     ("input-mat,i", po::value<std::string>()->required(),
-     "Input mutation-annotated tree file [REQUIRED]")
-    ("population-samples,s", po::value<std::string>()->required(),
-     "Names of samples from the population of interest [REQUIRED].")
+        "Input mutation-annotated tree file [REQUIRED]")
+    ("population-samples,s", po::value<std::string>()->required(), 
+        "Names of samples from the population of interest [REQUIRED].") 
     ("additional-info,a", po::bool_switch(),
-     "Set to calculate additional phylogenetic trait association statistics for whole regions and individual introductions. WARNING: Adds significantly to runtime.")
+    "Set to calculate additional phylogenetic trait association statistics for whole regions and individual introductions. WARNING: Adds significantly to runtime.")
     ("clade-regions,c", po::value<std::string>()->default_value(""),
-     "Set to optionally record, for each clade root in the tree, the support for that clade root being IN each region in the input, as a tsv with the indicated name.")
+    "Set to optionally record, for each clade root in the tree, the support for that clade root being IN each region in the input, as a tsv with the indicated name.")
     ("date-metadata,M", po::value<std::string>()->default_value(""),
-     "Pass a TSV or CSV containing a 'date' column to use for date information. If not used, date will be inferred from the sample name where possible.")
+    "Pass a TSV or CSV containing a 'date' column to use for date information. If not used, date will be inferred from the sample name where possible.")
     ("output,o", po::value<std::string>()->required(),
-     "Name of the file to save the introduction information to.")
+    "Name of the file to save the introduction information to.")
     ("origin-confidence,C", po::value<float>()->default_value(0.5),
-     "Set the threshold for recording of putative origins of introductions. Default is 0.5")
+    "Set the threshold for recording of putative origins of introductions. Default is 0.5")
     ("evaluate-metadata,E", po::bool_switch(),
-     "Set to assign each leaf a confidence value based on ancestor distance and confidence.")
+    "Set to assign each leaf a confidence value based on ancestor distance and confidence.")
     ("dump-assignments,D", po::value<std::string>()->default_value(""),
-     "Indicate a directory to which two-column text files containing node assignment values should be dumped for downstream processing.")
+    "Indicate a directory to which two-column text files containing node assignment values should be dumped for downstream processing.")
+    ("latest-date,l", po::value<std::string>()->default_value("1500/1/1"),
+    "Use to filter to clusters which have samples after the indicated date.")
     // ("threads,T", po::value<uint32_t>()->default_value(num_cores), num_threads_message.c_str())
     ("help,h", "Print help messages");
-=======
-        ("input-mat,i", po::value<std::string>()->required(),
-         "Input mutation-annotated tree file [REQUIRED]")
-        ("population-samples,s", po::value<std::string>()->required(), 
-         "Names of samples from the population of interest [REQUIRED].") 
-        ("additional-info,a", po::bool_switch(),
-        "Set to calculate additional phylogenetic trait association statistics for whole regions and individual introductions. WARNING: Adds significantly to runtime.")
-        ("clade-regions,c", po::value<std::string>()->default_value(""),
-        "Set to optionally record, for each clade root in the tree, the support for that clade root being IN each region in the input, as a tsv with the indicated name.")
-        ("date-metadata,M", po::value<std::string>()->default_value(""),
-        "Pass a TSV or CSV containing a 'date' column to use for date information. If not used, date will be inferred from the sample name where possible.")
-        ("output,o", po::value<std::string>()->required(),
-        "Name of the file to save the introduction information to.")
-        ("origin-confidence,C", po::value<float>()->default_value(0.5),
-        "Set the threshold for recording of putative origins of introductions. Default is 0.5")
-        ("evaluate-metadata,E", po::bool_switch(),
-        "Set to assign each leaf a confidence value based on ancestor distance and confidence.")
-        ("dump-assignments,D", po::value<std::string>()->default_value(""),
-        "Indicate a directory to which two-column text files containing node assignment values should be dumped for downstream processing.")
-        ("latest-date,l", po::value<std::string>()->default_value("1500/1/1"),
-        "Use to filter to clusters which have samples after the indicated date.")
-        // ("threads,T", po::value<uint32_t>()->default_value(num_cores), num_threads_message.c_str())
-        ("help,h", "Print help messages");
->>>>>>> more-introduction
     // Collect all the unrecognized options from the first pass. This will include the
     // (positional) command name, so we need to erase that.
     std::vector<std::string> opts = po::collect_unrecognized(parsed.options, po::include_positional);

--- a/src/matUtils/introduce.cpp
+++ b/src/matUtils/introduce.cpp
@@ -687,13 +687,15 @@ std::vector<std::string> find_introductions(MAT::Tree* T, std::map<std::string, 
                 ldatestr = boost::gregorian::to_simple_string(ldates.first) + "\t" + boost::gregorian::to_simple_string(ldates.second);
                 diff = (ldates.second - ldates.first);
             }
+            if (recency_filter > ldates.second) {
+                continue;
+            }
             date_tracker[cs.first] = ldatestr;
             float gv;
             gv = static_cast<float>(cs.second.size()) / static_cast<float>((int)(diff.days()/7)+1);
             growthv.emplace_back(gv);
             cgm[gv].emplace_back(cs.first);
         }
-        //assert (growthv.size() == clusters.size());
         //sort by default goes from smallest to largest
         //I want to rank by largest to smallest, so this is reversed.
         //tiebreaker ordering has to do with the order of samples encountered.

--- a/src/matUtils/introduce.cpp
+++ b/src/matUtils/introduce.cpp
@@ -398,7 +398,13 @@ std::pair<boost::gregorian::date,boost::gregorian::date> get_nearest_date(MAT::T
         if (in_samples->find(l) != in_samples->end()) {
             if (datemeta.size() > 0) {
                 if (datemeta.find(l) != datemeta.end()) {
-                    auto leafdate = boost::gregorian::from_string(datemeta.find(l)->second);
+                    boost::gregorian::date leafdate;
+                    try {
+                        leafdate = boost::gregorian::from_string(datemeta.find(l)->second);
+                    } catch (boost::bad_lexical_cast &e) {
+                        fprintf(stderr, "WARNING: Malformed date %s provided in date file for sample %s; ignoring sample date\n", datemeta.find(l)->second.c_str(), l.c_str());
+                        continue;
+                    }
                     if (leafdate < earliest) {
                         earliest = leafdate;
                     }

--- a/src/matUtils/introduce.cpp
+++ b/src/matUtils/introduce.cpp
@@ -9,6 +9,7 @@ po::variables_map parse_introduce_command(po::parsed_options parsed) {
     po::variables_map vm;
     po::options_description filt_desc("introduce options");
     filt_desc.add_options()
+<<<<<<< HEAD
     ("input-mat,i", po::value<std::string>()->required(),
      "Input mutation-annotated tree file [REQUIRED]")
     ("population-samples,s", po::value<std::string>()->required(),
@@ -29,6 +30,30 @@ po::variables_map parse_introduce_command(po::parsed_options parsed) {
      "Indicate a directory to which two-column text files containing node assignment values should be dumped for downstream processing.")
     // ("threads,T", po::value<uint32_t>()->default_value(num_cores), num_threads_message.c_str())
     ("help,h", "Print help messages");
+=======
+        ("input-mat,i", po::value<std::string>()->required(),
+         "Input mutation-annotated tree file [REQUIRED]")
+        ("population-samples,s", po::value<std::string>()->required(), 
+         "Names of samples from the population of interest [REQUIRED].") 
+        ("additional-info,a", po::bool_switch(),
+        "Set to calculate additional phylogenetic trait association statistics for whole regions and individual introductions. WARNING: Adds significantly to runtime.")
+        ("clade-regions,c", po::value<std::string>()->default_value(""),
+        "Set to optionally record, for each clade root in the tree, the support for that clade root being IN each region in the input, as a tsv with the indicated name.")
+        ("date-metadata,M", po::value<std::string>()->default_value(""),
+        "Pass a TSV or CSV containing a 'date' column to use for date information. If not used, date will be inferred from the sample name where possible.")
+        ("output,o", po::value<std::string>()->required(),
+        "Name of the file to save the introduction information to.")
+        ("origin-confidence,C", po::value<float>()->default_value(0.5),
+        "Set the threshold for recording of putative origins of introductions. Default is 0.5")
+        ("evaluate-metadata,E", po::bool_switch(),
+        "Set to assign each leaf a confidence value based on ancestor distance and confidence.")
+        ("dump-assignments,D", po::value<std::string>()->default_value(""),
+        "Indicate a directory to which two-column text files containing node assignment values should be dumped for downstream processing.")
+        ("latest-date,l", po::value<std::string>()->default_value("1500/1/1"),
+        "Use to filter to clusters which have samples after the indicated date.")
+        // ("threads,T", po::value<uint32_t>()->default_value(num_cores), num_threads_message.c_str())
+        ("help,h", "Print help messages");
+>>>>>>> more-introduction
     // Collect all the unrecognized options from the first pass. This will include the
     // (positional) command name, so we need to erase that.
     std::vector<std::string> opts = po::collect_unrecognized(parsed.options, po::include_positional);
@@ -435,12 +460,19 @@ std::pair<boost::gregorian::date,boost::gregorian::date> get_nearest_date(MAT::T
     return std::pair<boost::gregorian::date,boost::gregorian::date> (earliest,latest);
 }
 
-std::vector<std::string> find_introductions(MAT::Tree* T, std::map<std::string, std::vector<std::string>> sample_regions, bool add_info, std::string clade_output, float min_origin_confidence, std::string dump_assignments, bool eval_uncertainty, std::map<std::string, std::string> datemeta = {}) {
+std::vector<std::string> find_introductions(MAT::Tree* T, std::map<std::string, std::vector<std::string>> sample_regions, bool add_info, std::string clade_output, float min_origin_confidence, std::string dump_assignments, bool eval_uncertainty, std::string latest_date = "1700/1/1", std::map<std::string, std::string> datemeta = {}) {
     //for every region, independently assign IN/OUT states
     //and save these assignments into a map of maps
     //so we can check membership of introduction points in each of the other groups
     //this allows us to look for migrant flow between regions
     std::map<std::string, std::map<std::string, float>> region_assignments;
+    boost::gregorian::date recency_filter;
+    try {
+        recency_filter = boost::gregorian::from_string(latest_date);
+    } catch (const std::out_of_range& oor) {
+        fprintf(stderr, "ERROR: Minimum date argument (-l) could not be parsed. Check that it is formatted year-month-day and try again.\n");
+        exit(1);
+    }
     //TODO: This could be parallel for a significant speedup when dozens or hundreds of regions are being passed in
     //I also suspect I could use pointers for the assignment maps to make this more memory efficient
     for (auto ms: sample_regions) {
@@ -678,7 +710,7 @@ std::vector<std::string> find_introductions(MAT::Tree* T, std::map<std::string, 
             growthv.emplace_back(gv);
             cgm[gv].emplace_back(cs.first);
         }
-        assert (growthv.size() == clusters.size());
+        //assert (growthv.size() == clusters.size());
         //sort by default goes from smallest to largest
         //I want to rank by largest to smallest, so this is reversed.
         //tiebreaker ordering has to do with the order of samples encountered.
@@ -720,6 +752,9 @@ std::vector<std::string> find_introductions(MAT::Tree* T, std::map<std::string, 
                     //in order, first seven columns are
                     //sample id, cluster id, cluster rank, cluster growth score, earliest date, latest date, cluster size
                     //then the rest are the by-sample information (path, distance of this specific sample, yadda yadda)
+                    if (date_tracker.find(cid) == date_tracker.end()) {
+                        continue;
+                    }
                     cout << ss.first << "\t" << cid << "\t" << rankr << "\t" << gv << "\t" << date_tracker[cid] << "\t" << clusters[cid].size() << "\t" << span << ss.second;
                     outstrs.push_back(cout.str());
                 }
@@ -754,6 +789,7 @@ void introduce_main(po::parsed_options parsed) {
     std::string samples_filename = vm["population-samples"].as<std::string>();
     std::string clade_regions = vm["clade-regions"].as<std::string>();
     std::string metafile = vm["date-metadata"].as<std::string>();
+    std::string latest_date = vm["latest-date"].as<std::string>();
     bool add_info = vm["additional-info"].as<bool>();
     std::string output_file = vm["output"].as<std::string>();
     std::string dump_assignments = vm["dump-assignments"].as<std::string>();
@@ -781,7 +817,7 @@ void introduce_main(po::parsed_options parsed) {
             exit(1);
         }
     }
-    auto outstrings = find_introductions(&T, region_map, add_info, clade_regions, moconf, dump_assignments, leafconf, datemeta);
+    auto outstrings = find_introductions(&T, region_map, add_info, clade_regions, moconf, dump_assignments, leafconf, latest_date, datemeta);
 
     std::ofstream of;
     of.open(output_file);

--- a/src/matUtils/introduce.cpp
+++ b/src/matUtils/introduce.cpp
@@ -664,10 +664,16 @@ std::vector<std::string> find_introductions(MAT::Tree* T, std::map<std::string, 
             std::string ldatestr;
             MAT::Node* nn = T->get_node(cs.first);
             std::pair<boost::gregorian::date,boost::gregorian::date> ldates = get_nearest_date(T, nn, &sampleset, datemeta);
-            ldatestr = boost::gregorian::to_simple_string(ldates.first) + "\t" + boost::gregorian::to_simple_string(ldates.second);
+            boost::gregorian::days diff(0);
+            if ((ldates.first.is_not_a_date()) || (ldates.second.is_not_a_date())) {
+                fprintf(stderr, "WARNING: Cluster %s has no valid dates included among samples\n", cs.first.c_str());
+                ldatestr = "no-valid-date\tno-valid-date";
+            } else {
+                ldatestr = boost::gregorian::to_simple_string(ldates.first) + "\t" + boost::gregorian::to_simple_string(ldates.second);
+                diff = (ldates.second - ldates.first);
+            }
             date_tracker[cs.first] = ldatestr;
             float gv;
-            boost::gregorian::days diff(ldates.second - ldates.first);
             gv = static_cast<float>(cs.second.size()) / static_cast<float>((int)(diff.days()/7)+1);
             growthv.emplace_back(gv);
             cgm[gv].emplace_back(cs.first);

--- a/src/matUtils/introduce.hpp
+++ b/src/matUtils/introduce.hpp
@@ -1,5 +1,6 @@
 #include "common.hpp"
 #include <boost/date_time/gregorian/gregorian.hpp>
+#include <math.h>
 
 po::variables_map parse_introduce_command(po::parsed_options parsed);
 std::map<std::string, std::vector<std::string>> read_two_column (std::string sample_filename);


### PR DESCRIPTION
This smaller PR, partially inspired by the recent issues thread, includes the following updates:

1. A new option, (-l), which causes only clusters that were active at least as recently as the date string passed in with -l to be reported in the output.
2. Clusters are now sorted in the output by number of samples / weeks active instead of number of samples / days active.
3. Significantly improved error handling of unparseable dates and clusters without any parseable dates with and without metadata file input.