### PR TITLE
Fix odd profitable move count print out

### DIFF
--- a/src/matOptimize/optimize_tree.cpp
+++ b/src/matOptimize/optimize_tree.cpp
@@ -77,6 +77,9 @@ static void print_progress(
         double seconds_left = elpased_time.count() *
                               (total_nodes - checked_nodes_temp) /
                               checked_nodes_temp;
+        if(((deferred_nodes->size())&&(std::chrono::steady_clock::now()-last_save_time)>=save_period)||deferred_nodes->size()>=max_queued_moves){
+                return;
+        }
         fprintf(stderr,"\rchecked %d nodes, estimate %f min left,found %zu nodes "
                 "profitable",
                 checked_nodes_temp, seconds_left / 60, deferred_nodes->size());


### PR DESCRIPTION
#128 
Made progress meter exit early, so it won't count node not yet searched as profitable source nodes.