### PR TITLE
Title and description fields for Taxodium protobof output

### DIFF
--- a/src/matUtils/convert.cpp
+++ b/src/matUtils/convert.cpp
@@ -768,11 +768,14 @@ std::unordered_map<std::string, std::vector<std::string>> read_metafiles_tax(std
     }
     return metadata;
 }
-void save_taxodium_tree (MAT::Tree &tree, std::string out_filename, std::vector<std::string> meta_filenames, std::string gtf_filename, std::string fasta_filename) {
+void save_taxodium_tree (MAT::Tree &tree, std::string out_filename, std::vector<std::string> meta_filenames, std::string gtf_filename, std::string fasta_filename, std::string title, std::string description) {
 
     // These are the taxodium pb objects
     Taxodium::AllNodeData *node_data = new Taxodium::AllNodeData();
     Taxodium::AllData all_data;
+
+    all_data.set_tree_title(title);
+    all_data.set_tree_description(description);
 
     std::unordered_map<std::string, std::vector<std::string>> metadata = read_metafiles_tax(meta_filenames, all_data);
     TIMEIT();

--- a/src/matUtils/convert.hpp
+++ b/src/matUtils/convert.hpp
@@ -6,5 +6,5 @@ void write_json_from_mat(MAT::Tree* T, std::string output_filename, std::vector<
 MAT::Tree load_mat_from_json(std::string json_filename);
 void get_minimum_subtrees(MAT::Tree* T, std::vector<std::string> samples, size_t target_size, std::string output_dir, std::vector<std::map<std::string,std::map<std::string,std::string>>>* catmeta, std::string json_n, std::string newick_n, bool retain_original_branch_len = false);
 std::vector<std::string> get_nearby (MAT::Tree* T, std::string sample_id, int number_to_get);
-void save_taxodium_tree (MAT::Tree &tree, std::string out_filename, std::vector<std::string> meta_filenames, std::string gtf_filename, std::string fasta_filename);
+void save_taxodium_tree (MAT::Tree &tree, std::string out_filename, std::vector<std::string> meta_filenames, std::string gtf_filename, std::string fasta_filenames, std::string title, std::string description);
 std::unordered_map<std::string, std::vector<std::string>> read_metafiles_tax(std::vector<std::string> filenames, Taxodium::AllData &all_data);

--- a/src/matUtils/convert.hpp
+++ b/src/matUtils/convert.hpp
@@ -6,5 +6,5 @@ void write_json_from_mat(MAT::Tree* T, std::string output_filename, std::vector<
 MAT::Tree load_mat_from_json(std::string json_filename);
 void get_minimum_subtrees(MAT::Tree* T, std::vector<std::string> samples, size_t target_size, std::string output_dir, std::vector<std::map<std::string,std::map<std::string,std::string>>>* catmeta, std::string json_n, std::string newick_n, bool retain_original_branch_len = false);
 std::vector<std::string> get_nearby (MAT::Tree* T, std::string sample_id, int number_to_get);
-void save_taxodium_tree (MAT::Tree &tree, std::string out_filename, std::vector<std::string> meta_filenames, std::string gtf_filename, std::string fasta_filenames, std::string title, std::string description);
+void save_taxodium_tree (MAT::Tree &tree, std::string out_filename, std::vector<std::string> meta_filenames, std::string gtf_filename, std::string fasta_filename, std::string title, std::string description);
 std::unordered_map<std::string, std::vector<std::string>> read_metafiles_tax(std::vector<std::string> filenames, Taxodium::AllData &all_data);

--- a/src/matUtils/extract.cpp
+++ b/src/matUtils/extract.cpp
@@ -69,6 +69,10 @@ po::variables_map parse_extract_command(po::parsed_options parsed) {
      "Use to write a newick tree to the indicated file.")
     ("write-taxodium,l", po::value<std::string>()->default_value(""),
      "Write protobuf in alternate format consumed by Taxodium.")
+    ("title,B", po::value<std::string>()->default_value(""),
+     "Title of MAT to display in Taxodium (used with --write-taxodium).")
+    ("description,D", po::value<std::string>()->default_value(""),
+     "Description of MAT to display in Taxodium (used with --write-taxodium).")
     ("retain-branch-length,E", po::bool_switch(),
      "Use to not recalculate branch lengths when saving newick output. Used only with -t")
     ("minimum-subtrees-size,N", po::value<size_t>()->default_value(0),
@@ -147,6 +151,8 @@ void extract_main (po::parsed_options parsed) {
     std::string vcf_filename = dir_prefix + vm["write-vcf"].as<std::string>();
     std::string output_mat_filename = dir_prefix + vm["write-mat"].as<std::string>();
     std::string output_tax_filename = dir_prefix + vm["write-taxodium"].as<std::string>();
+    std::string tax_title = vm["title"].as<std::string>();
+    std::string tax_description = vm["description"].as<std::string>();
     std::string json_filename = dir_prefix + vm["write-json"].as<std::string>();
     std::string meta_filename = vm["metadata"].as<std::string>();
     std::string gtf_filename = dir_prefix + vm["input-gtf"].as<std::string>();
@@ -676,7 +682,7 @@ usher_single_subtree_size == 0 && usher_minimum_subtrees_size == 0) {
         if (!resolve_polytomies) {
             subtree.condense_leaves();
         }
-        save_taxodium_tree(subtree, output_tax_filename, metav, gtf_filename, fasta_filename);
+        save_taxodium_tree(subtree, output_tax_filename, metav, gtf_filename, fasta_filename, tax_title, tax_description);
         fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
     }
 }

--- a/taxodium.proto
+++ b/taxodium.proto
@@ -11,7 +11,6 @@ message AllNodeData {
 	repeated float y = 3;
 	repeated int32 countries = 4;
 	repeated int32 lineages = 5;
-
 	repeated MutationList mutations = 6;
 	repeated int32 dates = 7;
 	repeated int32 parents = 8;
@@ -21,9 +20,11 @@ message AllNodeData {
 }
 
 message AllData{
-	AllNodeData node_data = 1;
+	AllNodeData node_data= 1;
 	repeated string country_mapping = 2;
 	repeated string lineage_mapping = 3;
 	repeated string mutation_mapping = 4;
 	repeated string date_mapping = 5;
+	string tree_description = 6;
+	string tree_title = 7;
 }


### PR DESCRIPTION
Adds `--title` and `--description` options to `matUtils extract` for use with `--write-taxodium` (reflecting the Taxodium pb change [here](https://github.com/theosanderson/taxodium/commit/427cb457633e13f214763fd7678634ffb1e73b15)).

e.g. `matUtils extract --write-taxodium out.pb -i in.pb -g genes.gtf -f reference.fasta -M metadata.tsv --title "Taxodium Tree" --description "Description of the tree."`