### PR TITLE
Generic metadata for Taxodium export and amino-acid coloring fix

### DIFF
--- a/src/matUtils/convert.cpp
+++ b/src/matUtils/convert.cpp
@@ -794,7 +794,8 @@ std::unordered_map<std::string, std::vector<std::string>> read_metafiles_tax(std
                                 .column = i,
                                 .index = num_generic,
                                 .count = 0,
-                                .seen = empty_map
+                                .seen = empty_map,
+                                .protobuf_data_ptr = metadata_single
                             };
                             generic_metadata.push_back(new_meta);
                             num_generic ++;
@@ -861,7 +862,7 @@ void save_taxodium_tree (MAT::Tree &tree, std::string out_filename, std::vector<
     MetaColumns columns = {
         .strain_column = -1,
         .date_column = -1,
-        .genbank_column = -1
+        .genbank_column = -1,
     };
     
     std::vector<GenericMetadata> generic_metadata;

--- a/src/matUtils/convert.cpp
+++ b/src/matUtils/convert.cpp
@@ -681,7 +681,7 @@ void get_minimum_subtrees(MAT::Tree* T, std::vector<std::string> samples, size_t
 
 // Helper function to format one attribute into taxodium encoding for a SingleValuePerNode metadata type
 void populate_generic_metadata(int attribute_column, std::vector<std::string> &attributes, std::unordered_map<std::string, std::string> &seen_map, int &encoding_counter, Taxodium::MetadataSingleValuePerNode *single) {
-    if (attribute_column < attributes.size() && attributes[attribute_column] != "") {
+    if (attribute_column < (int) attributes.size() && attributes[attribute_column] != "") {
         std::string attr_val = attributes[attribute_column];
         if (seen_map.find(attr_val) == seen_map.end()) {
             encoding_counter++;
@@ -692,7 +692,7 @@ void populate_generic_metadata(int attribute_column, std::vector<std::string> &a
         } else {
             attributes[attribute_column] = seen_map[attr_val];
         }
-    } else if (attribute_column >= attributes.size()) { // deals with last column being empty
+    } else if (attribute_column >= (int) attributes.size()) { // deals with last column being empty
         attributes.push_back("0");
     } else {
         attributes[attribute_column] = "0";
@@ -755,7 +755,7 @@ std::unordered_map<std::string, std::vector<std::string>> read_metafiles_tax(std
             }
             MAT::string_split(line, delim, words);
             if (first) { // header line
-                for (int i = 0; i < words.size(); i++) { // for each column name
+                for (int i = 0; i < (int) words.size(); i++) { // for each column name
                     std::string field = words[i];
                     // Look for some defined metadata types.
                     // For now some fields are double-encoded as generic and fixed types.
@@ -765,10 +765,6 @@ std::unordered_map<std::string, std::vector<std::string>> read_metafiles_tax(std
                         columns.genbank_column = i;
                     } else if (field == "date") {
                         columns.date_column = i;
-                    } else if (field == "country") {
-                        // Temporary for backwards-compatibility
-                    } else if (field == "pangolin_lineage"){
-                        // Temporary for backwards-compatibility
                     }
                     // Encode everything else as generic
                     if (field != "strain" && field != "genbank_accession" && field != "date") {
@@ -802,7 +798,6 @@ std::unordered_map<std::string, std::vector<std::string>> read_metafiles_tax(std
                         }
                     }
                 }
-
                 
                 if (columns.strain_column == -1) {
                     fprintf(stderr, "ERROR: The required column \"strain\" is missing from the metadata\n");
@@ -818,6 +813,8 @@ std::unordered_map<std::string, std::vector<std::string>> read_metafiles_tax(std
                 fprintf(stderr, "-- %s %s\n", country_found ? found : missing, "country");
                 fprintf(stderr, "-- %s %s\n", lineage_found ? found : missing, "pangolin_lineage");
                 
+                fprintf(stderr, "\nIf any of the above fields are missing, importing into Taxodium may not work properly.\n");
+                
                 if (additional_meta_fields.size() > 0) {
                     additional_meta_fields.erase(std::remove(additional_meta_fields.begin(), additional_meta_fields.end(), "strain"), additional_meta_fields.end());
                     fprintf(stderr, "\nThe following additional metadata fields were specified:\n");
@@ -825,13 +822,13 @@ std::unordered_map<std::string, std::vector<std::string>> read_metafiles_tax(std
                         fprintf(stderr, "-- %s\n", name.c_str());
                     }
                 }
-                
+                fprintf(stderr, "\nPerforming conversion.\n");
                 first = false;
                 continue;
             }
 
             // Build mappings for generic metadata types
-            for (int i = 0; i < generic_metadata.size(); i++) {
+            for (int i = 0; i < (int) generic_metadata.size(); i++) {
                 populate_generic_metadata(generic_metadata[i].column, words, generic_metadata[i].seen, generic_metadata[i].count, node_data->mutable_metadata_singles(i));
             }
 
@@ -843,10 +840,8 @@ std::unordered_map<std::string, std::vector<std::string>> read_metafiles_tax(std
             std::string key = words[columns.strain_column];
             metadata[key] = words;
         }
-
         infile.close();
     }
-
     return metadata;
 }
 void save_taxodium_tree (MAT::Tree &tree, std::string out_filename, std::vector<std::string> meta_filenames, std::string gtf_filename, std::string fasta_filename, std::string title, std::string description, std::vector<std::string> additional_meta_fields) {

--- a/src/matUtils/convert.cpp
+++ b/src/matUtils/convert.cpp
@@ -758,7 +758,6 @@ std::unordered_map<std::string, std::vector<std::string>> read_metafiles_tax(std
                 for (int i = 0; i < (int) words.size(); i++) { // for each column name
                     std::string field = words[i];
                     // Look for some defined metadata types.
-                    // For now some fields are double-encoded as generic and fixed types.
                     if (field == "strain") {
                         columns.strain_column = i;
                     } else if (field == "genbank_accession") {

--- a/src/matUtils/convert.cpp
+++ b/src/matUtils/convert.cpp
@@ -700,7 +700,7 @@ void populate_generic_metadata(int attribute_column, std::vector<std::string> &a
 }
 
 // Helper function to populate non-generic metadata types that have mapping encodings.
-void populate_fixed_metadata(std::string name, int attribute_column, std::vector<std::string> &attributes, std::unordered_map<std::string, std::string> &seen_map, int &encoding_counter, Taxodium::AllData all_data) {
+void populate_fixed_metadata(std::string name, int attribute_column, std::vector<std::string> &attributes, std::unordered_map<std::string, std::string> &seen_map, int &encoding_counter, Taxodium::AllData &all_data) {
     if (seen_map.find(attributes[attribute_column]) == seen_map.end()) {
         encoding_counter++;
         std::string encoding_str = std::to_string(encoding_counter);
@@ -812,7 +812,7 @@ std::unordered_map<std::string, std::vector<std::string>> read_metafiles_tax(std
                 char found[]  = "(FOUND)";
                 char missing[] = "(MISSING)";
                 fprintf(stderr, "\nLooking for the following metadata fields:\n");
-                fprintf(stderr, "-- %s %s\n", found, "strain");
+                fprintf(stderr, "-- %s %s\n", found, "strain (this is the sample ID)");
                 fprintf(stderr, "-- %s %s\n", columns.genbank_column > -1 ? found : missing, "genbank_accession");
                 fprintf(stderr, "-- %s %s\n", columns.date_column > -1 ? found : missing, "date");
                 fprintf(stderr, "-- %s %s\n", country_found ? found : missing, "country");

--- a/src/matUtils/convert.hpp
+++ b/src/matUtils/convert.hpp
@@ -6,5 +6,5 @@ void write_json_from_mat(MAT::Tree* T, std::string output_filename, std::vector<
 MAT::Tree load_mat_from_json(std::string json_filename);
 void get_minimum_subtrees(MAT::Tree* T, std::vector<std::string> samples, size_t target_size, std::string output_dir, std::vector<std::map<std::string,std::map<std::string,std::string>>>* catmeta, std::string json_n, std::string newick_n, bool retain_original_branch_len = false);
 std::vector<std::string> get_nearby (MAT::Tree* T, std::string sample_id, int number_to_get);
-void save_taxodium_tree (MAT::Tree &tree, std::string out_filename, std::vector<std::string> meta_filenames, std::string gtf_filename, std::string fasta_filename, std::string title, std::string description);
-std::unordered_map<std::string, std::vector<std::string>> read_metafiles_tax(std::vector<std::string> filenames, Taxodium::AllData &all_data);
+void save_taxodium_tree (MAT::Tree &tree, std::string out_filename, std::vector<std::string> meta_filenames, std::string gtf_filename, std::string fasta_filename, std::string title, std::string description, std::vector<std::string> additional_meta_fields);
+std::unordered_map<std::string, std::vector<std::string>> read_metafiles_tax(std::vector<std::string> filenames, Taxodium::AllData &all_data, Taxodium::AllNodeData *node_data, MetaColumns &columns, std::vector<GenericMetadata> &generic_metadata, std::vector<std::string> additional_meta_fields);

--- a/src/matUtils/extract.cpp
+++ b/src/matUtils/extract.cpp
@@ -73,6 +73,8 @@ po::variables_map parse_extract_command(po::parsed_options parsed) {
      "Title of MAT to display in Taxodium (used with --write-taxodium).")
     ("description,D", po::value<std::string>()->default_value(""),
      "Description of MAT to display in Taxodium (used with --write-taxodium).")
+    ("extra-fields,F", po::value<std::string>()->default_value(""),
+     "Comma-separated list of additional metadata column names beyond the defaults of: strain, genbank_accession, country, date, pangolin_lineage (used with --write-taxodium).")
     ("retain-branch-length,E", po::bool_switch(),
      "Use to not recalculate branch lengths when saving newick output. Used only with -t")
     ("minimum-subtrees-size,N", po::value<size_t>()->default_value(0),
@@ -156,12 +158,15 @@ void extract_main (po::parsed_options parsed) {
     std::string output_tax_filename = dir_prefix + vm["write-taxodium"].as<std::string>();
     std::string tax_title = vm["title"].as<std::string>();
     std::string tax_description = vm["description"].as<std::string>();
+    std::string raw_meta_fields = vm["extra-fields"].as<std::string>();
     std::string json_filename = dir_prefix + vm["write-json"].as<std::string>();
     std::string meta_filename = vm["metadata"].as<std::string>();
     std::string gtf_filename = dir_prefix + vm["input-gtf"].as<std::string>();
     std::string fasta_filename = dir_prefix + vm["input-fasta"].as<std::string>();
 
-
+    std::vector<std::string> additional_meta_fields;
+    MAT::string_split(raw_meta_fields, ',', additional_meta_fields);
+    
     bool collapse_tree = vm["collapse-tree"].as<bool>();
     bool no_genotypes = vm["no-genotypes"].as<bool>();
     uint32_t num_threads = vm["threads"].as<uint32_t>();
@@ -689,7 +694,7 @@ usher_single_subtree_size == 0 && usher_minimum_subtrees_size == 0) {
         if (!resolve_polytomies) {
             subtree.condense_leaves();
         }
-        save_taxodium_tree(subtree, output_tax_filename, metav, gtf_filename, fasta_filename, tax_title, tax_description);
+        save_taxodium_tree(subtree, output_tax_filename, metav, gtf_filename, fasta_filename, tax_title, tax_description, additional_meta_fields);
         fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
     }
 }

--- a/src/matUtils/translate.cpp
+++ b/src/matUtils/translate.cpp
@@ -296,9 +296,8 @@ void translate_and_populate_node_data(MAT::Tree *T, std::string gtf_filename, st
             if (fixed_columns.genbank_column > -1) {
                 node_data->add_genbanks("");
             }
-            for (auto generic : generic_metadata ) {
-                auto generic_node_data = node_data->mutable_metadata_singles(generic.index);
-                generic_node_data->add_node_values(0); // no metadata for this node
+            for (int i = 0; i < generic_metadata.size(); i++ ) {
+                generic_metadata[i].protobuf_data_ptr->add_node_values(0); // no metadata for this node
             }
         } else if (metadata.find(node->identifier) == metadata.end()) { 
             node_data->add_names(split(node->identifier, '|')[0]);
@@ -309,10 +308,9 @@ void translate_and_populate_node_data(MAT::Tree *T, std::string gtf_filename, st
             if (fixed_columns.genbank_column > -1) {
                 node_data->add_genbanks("");
             }
-            for (auto generic : generic_metadata ) {
-                auto generic_node_data = node_data->mutable_metadata_singles(generic.index);
-                generic_node_data->add_node_values(0); // no metadata for this node
-           }
+            for (int i = 0; i < generic_metadata.size(); i++ ) {
+                generic_metadata[i].protobuf_data_ptr->add_node_values(0); // no metadata for this node
+            }
         
         } else {
 
@@ -328,9 +326,8 @@ void translate_and_populate_node_data(MAT::Tree *T, std::string gtf_filename, st
 
             node_data->add_names(split(node->identifier, '|')[0]);
 
-            for (auto generic : generic_metadata ) {
-                auto generic_node_data = node_data->mutable_metadata_singles(generic.index);
-                generic_node_data->add_node_values(std::stoi(meta_fields[generic.column])); // lookup the encoding for this value
+            for (int i = 0; i < generic_metadata.size(); i++ ) {
+                generic_metadata[i].protobuf_data_ptr->add_node_values(std::stoi(meta_fields[generic_metadata[i].column])); // lookup the encoding for this value
             }
         }
 

--- a/src/matUtils/translate.hpp
+++ b/src/matUtils/translate.hpp
@@ -14,6 +14,7 @@ typedef struct {
     int index; // index in proto list
     int32_t count; // used for building mapping
     std::unordered_map<std::string, std::string> seen; // used for building mapping
+    Taxodium::MetadataSingleValuePerNode *protobuf_data_ptr;
 } GenericMetadata;
 
 static std::unordered_map<std::string, char> translation_map= {

--- a/src/matUtils/translate.hpp
+++ b/src/matUtils/translate.hpp
@@ -1,7 +1,20 @@
 #include "common.hpp"
 #include "taxodium.pb.h"
 
-enum Fields {genbank_col, date_col, country_col, host_col, completeness_col, length_col, clade_col, lineage_col, index_col};
+// column numbers of fixed metadata
+typedef struct {
+	int strain_column;
+	int date_column;
+	int genbank_column;
+} MetaColumns;
+
+typedef struct {
+    std::string name;
+    int column; // column in metadata file
+    int index; // index in proto list
+    int32_t count; // used for building mapping
+    std::unordered_map<std::string, std::string> seen; // used for building mapping
+} GenericMetadata;
 
 static std::unordered_map<std::string, char> translation_map= {
     {"GCT", 'A'}, {"GCC", 'A'}, {"GCA", 'A'}, {"GCG", 'A'}, {"GCN", 'A'},
@@ -72,8 +85,8 @@ struct Codon {
     }
 };
 
-std::string do_mutations(std::vector<MAT::Mutation> &mutations, std::map<int, std::vector<std::shared_ptr<Codon>>> &codon_map, bool taxodium_format);
+std::string do_mutations(std::vector<MAT::Mutation> &mutations, std::unordered_map<int, std::vector<std::shared_ptr<Codon>>> &codon_map, bool taxodium_format);
 void translate_main(MAT::Tree *T, std::string output_filename, std::string gff_filename, std::string fasta_filename);
-void translate_and_populate_node_data(MAT::Tree *T, std::string gtf_filename, std::string fasta_filename, Taxodium::AllNodeData *node_data, Taxodium::AllData *all_data, std::unordered_map<std::string, std::vector<std::string>> &metadata);
-void cleanup_codon_map(std::map<int, std::vector<std::shared_ptr<Codon>>> &codon_map);
-void undo_mutations(std::vector<MAT::Mutation> &mutations, std::map<int, std::vector<std::shared_ptr<Codon>>> &codon_map);
+void translate_and_populate_node_data(MAT::Tree *T, std::string gtf_filename, std::string fasta_filename, Taxodium::AllNodeData *node_data, Taxodium::AllData *all_data, std::unordered_map<std::string, std::vector<std::string>> &metadata, MetaColumns fixed_columns, std::vector<GenericMetadata> &generic_metadata);
+void cleanup_codon_map(std::unordered_map<int, std::vector<std::shared_ptr<Codon>>> &codon_map);
+void undo_mutations(std::vector<MAT::Mutation> &mutations, std::unordered_map<int, std::vector<std::shared_ptr<Codon>>> &codon_map);

--- a/taxodium.proto
+++ b/taxodium.proto
@@ -5,24 +5,35 @@ message MutationList{
 	repeated int32 mutation = 1;
 }
 
+message MetadataSingleValuePerNode{
+	string metadata_name = 1;
+	string metadata_title = 2;
+	repeated string mapping = 3;
+	repeated int32 node_values = 4;
+}
+
 message AllNodeData {
 	repeated string names = 1;
 	repeated float x = 2;
 	repeated float y = 3;
-	repeated int32 countries = 4;
-	repeated int32 lineages = 5;
-	repeated MutationList mutations = 6;
+	repeated int32 countries = 4;//Deprecated: DO NOT USE (use metadata_singles)
 	repeated int32 dates = 7;
+	repeated int32 lineages = 5;//Deprecated: DO NOT USE (use metadata_singles)
+
+	repeated MutationList mutations = 6; 
 	repeated int32 parents = 8;
 	repeated string genbanks = 9;
 	repeated int32 epi_isl_numbers = 10;
 	repeated int32 num_tips = 11;
+	repeated MetadataSingleValuePerNode metadata_singles = 12;
+
 }
+
 
 message AllData{
 	AllNodeData node_data= 1;
-	repeated string country_mapping = 2;
-	repeated string lineage_mapping = 3;
+	repeated string country_mapping = 2;//Deprecated: DO NOT USE (use metadata_singles above)
+	repeated string lineage_mapping = 3; //Deprecated: DO NOT USE (use metadata_singles above)
 	repeated string mutation_mapping = 4;
 	repeated string date_mapping = 5;
 	string tree_description = 6;


### PR DESCRIPTION
Introduces ability to add generic metadata to Taxodium-format exports (#154) and adds a fix for amino-acid coloring (#149)
#### Generic metadata
1. Some changes to the way metadata is read are added. Column headers are now used to determine metadata types. Columns may be in any order, and the following columns are explicitly looked for: `strain` (the sample ID),  `genbank_accession`, `date`, `country`, `pangolin_lineage`. These names match the column names of metadata from the [FTP site](https://hgdownload.soe.ucsc.edu/goldenPath/wuhCor1/UShER_SARS-CoV-2/).
2. The `country` and `pangolin_lineage` fields, if present, are added to the protobuf as `MetadataSingleValuePerNode` types as per the latest Taxodium [proto file](https://github.com/theosanderson/taxodium/blob/9ef607a41bbf6991f07c6ded44863be3cc992e39/public/taxodium.proto). The `metadata_name` fields are set to `Country` and `Lineage` as expected by Taxodium.
2. Additional metadata fields may be specified using `-F`, which will include the metadata as generic `MetadataSingleValuePerNode` types, with `metadata_name` equal to their column name. e.g. 
`matUtils extract -i in.pb --write-taxodium out.pb -g genes.gtf -f ref.fasta -M metadata.tsv -F custom_field_1,custom_field_2`

#### Amino acid coloring
A "mutation" is now added at the root node for each codon in the reference sequence as part of the protobuf output. See #149 