### PR TITLE
Correctly handle multiple metadata files in taxodium export mode

### DIFF
--- a/src/matUtils/translate.cpp
+++ b/src/matUtils/translate.cpp
@@ -349,10 +349,6 @@ void translate_and_populate_node_data(MAT::Tree *T, std::string gtf_filename, st
 
             node_data->add_names(split(node->identifier, '|')[0]);
 
-            for (auto m : meta_fields) {
-                std::cout << m << " ";
-            }
-            std::cout << '\n';
             for (const auto &m : generic_metadata) {
                 m.protobuf_data_ptr->add_node_values(std::stoi(meta_fields[m.column])); // lookup the encoding for this value
             }


### PR DESCRIPTION
This fixes `matUtils extract --write-taxodium` to properly handle multiple metadata files specified with e.g. `-M file1,file2`

A `strain` column with sample ID must be present in each metadata file.

If the same field exists in multiple metadata files, the values from the last occurrence are used.