### PR TITLE
matUtils annotate: Added option --clade-mutations (-M) for specifying clades by sets of mutations

### DIFF
--- a/src/matUtils/annotate.hpp
+++ b/src/matUtils/annotate.hpp
@@ -3,5 +3,5 @@
 po::variables_map parse_annotate_command(po::parsed_options parsed);
 void annotate_main(po::parsed_options parsed);
 void assignLineages (MAT::Tree& T, const std::string& lineage_filename, bool clear_current = false);
-void assignLineages (MAT::Tree& T, const std::string& lineage_filename, float min_freq, float mask_freq, float set_overlap, float clip_sample_frequency, bool clear_current = false, const std::string& mutations_filename = "", const std::string& details_filename = "");
+void assignLineages (MAT::Tree& T, const std::string& clade_filename, const std::string& clade_mutations_filename, float min_freq, float mask_freq, float set_overlap, float clip_sample_frequency, bool clear_current = false, const std::string& mutations_filename = "", const std::string& details_filename = "");
 void assignLineagesFromPaths (MAT::Tree& T, const std::string& clade_paths_filename, bool clear_current = false);


### PR DESCRIPTION
Sets of mutations are more stable than paths in which the order of mutations can change over time as new samples are added.  The input format is the same as for --clade-paths except back-mutations are not tolerated; each position must appear only once per clade.
--clade-mutations and --clade-names can be used together or separately.  If they are used together then --clade-mutations takes precedence; sample names are ignored if mutations are specified for their clades.  This is because the mutation sets are intended to be carefully curated, while we expect some noise in representative sample sets, especially for older lineages.