### PR TITLE
switch back to openmpi

### DIFF
--- a/install/environment.yml
+++ b/install/environment.yml
@@ -15,5 +15,5 @@ dependencies:
   - git
   - wget
   - rsync
-  - intel::impi-devel=2021.4.0
+  - openmpi
   - isa-l


### PR DESCRIPTION
Intel MPI is not available on mac, so switch back to openmpi on conda local install.