### PR TITLE
Whitelist in matUtils extract + refactoring of introduce

### DIFF
--- a/src/matUtils/introduce.cpp
+++ b/src/matUtils/introduce.cpp
@@ -330,12 +330,11 @@ std::unordered_map<std::string, float> get_assignments(MAT::Tree* T, std::unorde
                     }
                 }
             }
-            assert (min_to_in != 10000000);
-            assert (min_to_out != 10000000);
             stored_params[n->identifier][0] = in_leaves;
             stored_params[n->identifier][1] = out_leaves;
             stored_params[n->identifier][2] = min_to_in;
             stored_params[n->identifier][3] = min_to_out;
+            // fprintf(stderr, "DEBUG: min %ld, mout %ld, ols %ld, ils %ld\n", min_to_in, min_to_out, out_leaves, in_leaves);
             if (out_leaves == 0) {
                 //rule 2
                 assignments[n->identifier] = 1;
@@ -809,7 +808,6 @@ std::vector<std::string> find_introductions(MAT::Tree* T, std::unordered_map<std
                     continue;
                 }
                 ldatestr = boost::gregorian::to_simple_string(ldates.first) + "\t" + boost::gregorian::to_simple_string(ldates.second);
-                //diff = (ldates.second - ldates.first);
                 diff = (boost::gregorian::day_clock::universal_day() - ldates.first); //try weighting growth by current date to change top cluster display.
             }
             date_tracker[cs.first] = ldatestr;


### PR DESCRIPTION
This PR includes a quick request from @russcd this morning to whitelist samples that would otherwise be pruned or not included, added to matUtils extract. It takes a simple list of samples to always retain, not otherwise manipulable or combined with other selection logic. 

Additionally, this PR includes some ongoing work on my part to clean up, refactor, and do some optimizations to matUtils introduce ahead of publication. It also includes a bugfix that will change exactly what clusters are called when I propagate it to the website. It is notably faster and should be somewhat better for memory as well. 