### PR TITLE
faster Ripples 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:20.04
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
+ENV DEBIAN_FRONTEND=noninteractive
+USER root
+RUN apt-get update && apt-get install -yq --no-install-recommends \
+    git wget \
+    ca-certificates \
+wget cmake  libboost-filesystem-dev libboost-program-options-dev libboost-iostreams-dev libboost-date-time-dev \
+ libprotoc-dev libprotoc-dev protobuf-compiler openssl openssh-client vim \
+ mafft rsync libtbb-dev mpich libmpich-dev automake libtool autoconf make nasm gdb && apt clean
+
+RUN mkdir ISAL&& \
+    cd ISAL&& \
+    wget https://github.com/intel/isa-l/archive/refs/tags/v2.30.0.tar.gz && \
+    tar -xvf v2.30.0.tar.gz && \
+    cd isa-l-2.30.0 && \
+    ./autogen.sh && \
+    ./configure && \
+    make -j$(nproc) && \
+    make install && \
+    cd .. && rm -rf ISAL
+LABEL Name=usher-dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": ".",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "./Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	 "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ]
+
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ configure_file(src/version.hpp.in version.hpp)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -std=c++17 -Wall -g -Wno-unused-function  -Wno-deprecated-declarations") 
 #-DDEBUG_PARSIMONY_SCORE_CHANGE_CORRECT  -DCHECK_PAR_MAIN  -DEASY_DEBUG -DSTOP_ON_ERROR    -fsanitize=address
-set(CMAKE_CXX_FLAGS_DEBUG "-fsanitize=address")
+set(CMAKE_CXX_FLAGS_DEBUG "-fsanitize=address -O0 -ggdb3 -fno-eliminate-unused-debug-symbols")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-DNDEBUG -O3")
 set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG -O3")
 set(CMAKE_INCLUDE_CURRENT_DIR ON) 
@@ -52,9 +52,10 @@ AUX_SOURCE_DIRECTORY(src/matOptimize/Profitable_Moves_Enumerators New_Profitable
 AUX_SOURCE_DIRECTORY(src/matOptimize/apply_move patch_tree) 
 file(GLOB MATUTIL_SRCS "src/matUtils/*.cpp" "src/matUtils/*.hpp")
 file(GLOB RIPPLES_SRCS "src/ripples/*.cpp" "src/ripples/*.hpp")
+file(GLOB RIPPLES_FAST_SRCS "src/ripples/ripples_fast/*.cpp" "src/ripples/ripples_fast/*.hpp")
 
-#set_source_files_properties(src/matOptimize/Profitable_Moves_Enumerators/upward_integrated.cpp PROPERTIES COMPILE_FLAGS -O0)
-#set_source_files_properties(src/matOptimize/Profitable_Moves_Enumerators/downward_integrated.cpp PROPERTIES COMPILE_FLAGS -O0)
+set_source_files_properties(src/mutation_annotated_tree.cpp PROPERTIES COMPILE_FLAGS -O3)
+#set_source_files_properties(src/usher_mapper.cpp PROPERTIES COMPILE_FLAGS -O3)
 #set_source_files_properties(src/matOptimize/Profitable_Moves_Enumerators/range_tree.cpp PROPERTIES COMPILE_FLAGS -O0)
 
 #set_source_files_properties(src/matOptimize/detailed_mutations_store.cpp PROPERTIES COMPILE_FLAGS -O0)
@@ -214,6 +215,13 @@ else()
         ${PROTO_HDRS}
         )
 
+    add_executable(ripples-fast
+        src/mutation_annotated_tree.cpp
+        src/usher_mapper.cpp
+        ${RIPPLES_FAST_SRCS}
+        ${PROTO_SRCS}
+        ${PROTO_HDRS}
+        )
 
     add_executable(compareVCF
         src/mutation_annotated_tree.cpp
@@ -347,6 +355,7 @@ TARGET_LINK_LIBRARIES(matUtils PRIVATE stdc++  ${Boost_LIBRARIES} ${TBB_IMPORTED
 
 TARGET_COMPILE_OPTIONS(ripples PRIVATE -DTBB_SUPPRESS_DEPRECATED_MESSAGES)
 TARGET_LINK_LIBRARIES(ripples PRIVATE stdc++  ${Boost_LIBRARIES} ${TBB_IMPORTED_TARGETS} ${Protobuf_LIBRARIES}) # OpenMP::OpenMP_CXX)
+TARGET_LINK_LIBRARIES(ripples-fast PRIVATE stdc++  ${Boost_LIBRARIES} ${TBB_IMPORTED_TARGETS} ${Protobuf_LIBRARIES}) # OpenMP::OpenMP_CXX)
 
 if(USHER_SERVER)
     TARGET_COMPILE_OPTIONS(usher_server PRIVATE -DTBB_SUPPRESS_DEPRECATED_MESSAGES)

--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -13,7 +13,7 @@
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 #include "usher_graph.hpp"
-
+#include <signal.h>
 // Uses one-hot encoding if base is unambiguous
 // A:1,C:2,G:4,T:8
 int8_t Mutation_Annotated_Tree::get_nuc_id (char nuc) {

--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -1141,10 +1141,12 @@ std::vector<Mutation_Annotated_Tree::Node*> Mutation_Annotated_Tree::Tree::bread
 }
 
 void Mutation_Annotated_Tree::Tree::depth_first_expansion_helper(Mutation_Annotated_Tree::Node* node, std::vector<Mutation_Annotated_Tree::Node*>& vec) const {
+    node->dfs_idx=vec.size();
     vec.push_back(node);
     for (auto c: node->children) {
         depth_first_expansion_helper(c, vec);
     }
+    node->dfs_end_idx=vec.size();
 }
 
 std::vector<Mutation_Annotated_Tree::Node*> Mutation_Annotated_Tree::Tree::depth_first_expansion(Mutation_Annotated_Tree::Node* node) const {

--- a/src/mutation_annotated_tree.hpp
+++ b/src/mutation_annotated_tree.hpp
@@ -86,6 +86,8 @@ class Node {
     Node* parent;
     std::vector<Node*> children;
     std::vector<Mutation> mutations;
+    size_t dfs_idx;
+    size_t dfs_end_idx;
 
     bool is_leaf();
     bool is_root();

--- a/src/ripples/main.cpp
+++ b/src/ripples/main.cpp
@@ -220,10 +220,9 @@ int main(int argc, char** argv) {
                 fprintf(stderr, "ERROR: Node id %s not found!\n", words[0].c_str());
                 exit(1);
             } else {
-                /*for (auto anc: T.rsearch(n->identifier, true)) {
+                for (auto anc: T.rsearch(n->identifier, true)) {
                     nodes_to_consider.insert(anc->identifier);
-                }*/
-                nodes_to_consider.insert(n->identifier);
+                }
             }
         }
         infile.close();
@@ -299,7 +298,7 @@ int main(int argc, char** argv) {
     }
 
     fprintf(stderr, "Running placement individually for %zu branches to identify potential recombination events.\n", e-s);
-    FILE* before_joining_fh=fopen("before_join_ref","w");
+
     size_t num_done = 0;
     for (size_t idx = s; idx < e; idx++) {
         auto nid_to_consider = nodes_to_consider_vec[idx];
@@ -682,12 +681,7 @@ int main(int argc, char** argv) {
             }
         }
         fprintf(stderr, "\n");
-        for(auto p: valid_pairs) {
-            std::string end_range_high_str = (p.end_range_high == 1e9) ? "GENOME_SIZE" : std::to_string(p.end_range_high);
-            fprintf(before_joining_fh, "%s\t(%i,%i)\t(%i,%s)\t%s\t%s\n", nid_to_consider.c_str(), p.start_range_low,
-                    p.start_range_high, p.end_range_low, end_range_high_str.c_str(), p.d.name.c_str(),p.a.name.c_str());
-            fflush(before_joining_fh);
-        }
+
         valid_pairs = combine_intervals(valid_pairs);
         //print combined pairs
         for(auto p: valid_pairs) {

--- a/src/ripples/main.cpp
+++ b/src/ripples/main.cpp
@@ -220,9 +220,10 @@ int main(int argc, char** argv) {
                 fprintf(stderr, "ERROR: Node id %s not found!\n", words[0].c_str());
                 exit(1);
             } else {
-                for (auto anc: T.rsearch(n->identifier, true)) {
+                /*for (auto anc: T.rsearch(n->identifier, true)) {
                     nodes_to_consider.insert(anc->identifier);
-                }
+                }*/
+                nodes_to_consider.insert(n->identifier);
             }
         }
         infile.close();

--- a/src/ripples/main.cpp
+++ b/src/ripples/main.cpp
@@ -299,7 +299,7 @@ int main(int argc, char** argv) {
     }
 
     fprintf(stderr, "Running placement individually for %zu branches to identify potential recombination events.\n", e-s);
-
+    FILE* before_joining_fh=fopen("before_join_ref","w");
     size_t num_done = 0;
     for (size_t idx = s; idx < e; idx++) {
         auto nid_to_consider = nodes_to_consider_vec[idx];
@@ -682,7 +682,12 @@ int main(int argc, char** argv) {
             }
         }
         fprintf(stderr, "\n");
-
+        for(auto p: valid_pairs) {
+            std::string end_range_high_str = (p.end_range_high == 1e9) ? "GENOME_SIZE" : std::to_string(p.end_range_high);
+            fprintf(before_joining_fh, "%s\t(%i,%i)\t(%i,%s)\t%s\t%s\n", nid_to_consider.c_str(), p.start_range_low,
+                    p.start_range_high, p.end_range_low, end_range_high_str.c_str(), p.d.name.c_str(),p.a.name.c_str());
+            fflush(before_joining_fh);
+        }
         valid_pairs = combine_intervals(valid_pairs);
         //print combined pairs
         for(auto p: valid_pairs) {

--- a/src/ripples/ripples_fast/main.cpp
+++ b/src/ripples/ripples_fast/main.cpp
@@ -4,7 +4,6 @@
 #include <array>
 #include <boost/filesystem.hpp>
 #include <fstream>
-#include <iostream>
 #include <memory>
 #include <random>
 #include <time.h>

--- a/src/ripples/ripples_fast/main.cpp
+++ b/src/ripples/ripples_fast/main.cpp
@@ -1,0 +1,740 @@
+#include "ripples.hpp"
+#include "src/usher_graph.hpp"
+#include "tbb/concurrent_unordered_set.h"
+#include <array>
+#include <boost/filesystem.hpp>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <time.h>
+#include <vector>
+#define CHECK_MAPPER
+Timer timer;
+int main(int argc, char **argv) {
+    po::variables_map vm = check_options(argc, argv);
+    std::string input_mat_filename = vm["input-mat"].as<std::string>();
+    std::string outdir = vm["outdir"].as<std::string>();
+    std::string samples_filename = vm["samples-filename"].as<std::string>();
+    uint32_t branch_len = vm["branch-length"].as<uint32_t>();
+    int parsimony_improvement = vm["parsimony-improvement"].as<int>();
+    int max_range = vm["max-coordinate-range"].as<int>();
+    int min_range = vm["min-coordinate-range"].as<int>();
+    uint32_t num_descendants = vm["num-descendants"].as<uint32_t>();
+    int start_idx = vm["start-index"].as<int>();
+    int end_idx = vm["end-index"].as<int>();
+    uint32_t num_threads = vm["threads"].as<uint32_t>();
+
+    tbb::task_scheduler_init init(num_threads);
+    srand(time(NULL));
+
+    static tbb::affinity_partitioner ap;
+
+    timer.Start();
+    fprintf(stderr, "Loading input MAT file %s.\n", input_mat_filename.c_str());
+
+    // Load input MAT and uncondense tree
+    MAT::Tree T = MAT::load_mutation_annotated_tree(input_mat_filename);
+    T.uncondense_leaves();
+    fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
+
+    timer.Start();
+
+    fprintf(stderr,
+            "Finding the branches with number of mutations equal to or "
+            "exceeding %u.\n",
+            branch_len);
+    auto bfs = T.breadth_first_expansion();
+
+    tbb::concurrent_unordered_set<std::string> nodes_to_consider;
+
+    if (samples_filename != "") {
+        std::ifstream infile(samples_filename);
+        if (!infile) {
+            fprintf(stderr, "ERROR: Could not open the samples file: %s!\n",
+                    samples_filename.c_str());
+            exit(1);
+        }
+        std::string line;
+
+        fprintf(stderr, "Reading samples from the file %s.\n",
+                samples_filename.c_str());
+        timer.Start();
+        while (std::getline(infile, line)) {
+            std::vector<std::string> words;
+            MAT::string_split(line, words);
+            if (words.size() != 1) {
+                fprintf(stderr,
+                        "ERROR: Incorrect format for samples file: %s!\n",
+                        samples_filename.c_str());
+                exit(1);
+            }
+            auto n = T.get_node(words[0]);
+            if (n == NULL) {
+                fprintf(stderr, "ERROR: Node id %s not found!\n",
+                        words[0].c_str());
+                exit(1);
+            } else {
+                /*for (auto anc : T.rsearch(n->identifier, true)) {
+                    nodes_to_consider.insert(anc->identifier);
+                }*/
+                nodes_to_consider.insert(n->identifier);
+            }
+        }
+        infile.close();
+    } else {
+        tbb::parallel_for(
+            tbb::blocked_range<size_t>(0, bfs.size()),
+            [&](const tbb::blocked_range<size_t> r) {
+                for (size_t i = r.begin(); i < r.end(); ++i) {
+                    auto n = bfs[i];
+                    if (n == T.root) {
+                        continue;
+                    }
+                    if (n->mutations.size() >= branch_len) {
+                        if (T.get_num_leaves(n) >= num_descendants) {
+                            nodes_to_consider.insert(n->identifier);
+                        }
+                    }
+                }
+            },
+            ap);
+    }
+
+    std::vector<std::string> nodes_to_consider_vec;
+    for (auto elem : nodes_to_consider) {
+        nodes_to_consider_vec.emplace_back(elem);
+    }
+    std::sort(nodes_to_consider_vec.begin(), nodes_to_consider_vec.end());
+    std::shuffle(nodes_to_consider_vec.begin(), nodes_to_consider_vec.end(),
+                 std::default_random_engine(0));
+
+    fprintf(stderr, "Found %zu long branches\n", nodes_to_consider.size());
+    fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
+
+    fprintf(stderr, "Creating output files.\n");
+    boost::filesystem::path path(outdir);
+    if (!boost::filesystem::exists(path)) {
+        boost::filesystem::create_directory(path);
+    }
+
+    path = boost::filesystem::canonical(outdir);
+    outdir = path.generic_string();
+
+    auto desc_filename = outdir + "/descendants.tsv";
+    fprintf(stderr,
+            "Creating file %s to write descendants of recombinant nodes\n",
+            desc_filename.c_str());
+    FILE *desc_file = fopen(desc_filename.c_str(), "w");
+    fprintf(desc_file, "#node_id\tdescendants\n");
+
+    auto recomb_filename = outdir + "/recombination.tsv";
+    fprintf(stderr, "Creating file %s to write recombination events\n",
+            recomb_filename.c_str());
+    FILE *recomb_file = fopen(recomb_filename.c_str(), "w");
+    fprintf(
+        recomb_file,
+        "#recomb_node_id\tbreakpoint-1_interval\tbreakpoint-2_interval\tdonor_"
+        "node_id\tdonor_is_sibling\tdonor_parsimony\tacceptor_node_"
+        "id\tacceptor_is_sibling\tacceptor_parsimony\toriginal_parsimony\tmin_"
+        "starting_parsimony\trecomb_parsimony\n");
+    fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
+
+    timer.Start();
+
+    std::unordered_map<MAT::Node *, size_t> tree_num_leaves;
+    auto dfs=T.depth_first_expansion();
+    for (int i = int(bfs.size()) - 1; i >= 0; i--) {
+        auto n = bfs[i];
+        size_t desc = 1;
+        for (auto child : n->children) {
+            desc += tree_num_leaves[child];
+        }
+        tree_num_leaves[n] = desc;
+        if(desc!=n->dfs_end_idx-n->dfs_idx){
+            fprintf(stderr, "Expected Descendant Size: %ld, go %ld",desc,n->dfs_end_idx-n->dfs_idx);
+            raise(SIGTRAP);
+        }
+    }
+
+    size_t s = 0, e = nodes_to_consider.size();
+
+    if ((start_idx >= 0) && (end_idx >= 0)) {
+        s = start_idx;
+        if (end_idx <= (int)e) {
+            e = end_idx;
+        }
+    }
+
+    fprintf(stderr,
+            "Running placement individually for %zu branches to identify "
+            "potential recombination events.\n",
+            e - s);
+
+    size_t num_done = 0;
+    auto node_size=dfs.size();
+    for (size_t idx = s; idx < e; idx++) {
+        auto nid_to_consider = nodes_to_consider_vec[idx];
+        fprintf(stderr, "At node id: %s\n", nid_to_consider.c_str());
+
+        int orig_parsimony = (int)T.get_node(nid_to_consider)->mutations.size();
+
+        Pruned_Sample pruned_sample(nid_to_consider);
+        // Find mutations on the node to prune
+        auto node_to_root = T.rsearch(nid_to_consider, true);
+        for (auto curr : node_to_root) {
+            for (auto m : curr->mutations) {
+                pruned_sample.add_mutation(m);
+            }
+        }
+        size_t num_mutations = pruned_sample.sample_mutations.size();
+
+        size_t total_nodes = bfs.size();
+
+        /*std::vector<std::vector<MAT::Mutation>> node_excess_mutations(
+            total_nodes);
+        std::vector<std::vector<MAT::Mutation>> imputed_mutations(total_nodes);
+
+        std::vector<int> node_set_difference(total_nodes);
+
+        size_t best_node_num_leaves = 0;
+        int best_set_difference = 1e9;
+
+        std::vector<bool> node_has_unique(total_nodes);
+        size_t best_j = 0;
+        bool best_node_has_unique = false;
+
+        size_t best_distance = 1e9;
+
+        std::vector<size_t> best_j_vec;
+
+        size_t num_best = 1;
+        MAT::Node *best_node = T.root;
+        best_j_vec.emplace_back(0);
+
+        std::vector<size_t> node_distance(total_nodes, 0);
+
+
+        tbb::parallel_for(
+            tbb::blocked_range<size_t>(0, total_nodes),
+            [&](tbb::blocked_range<size_t> r) {
+                for (size_t k = r.begin(); k < r.end(); ++k) {
+                    if (tree_num_leaves[bfs[k]] < num_descendants) {
+                        continue;
+                    }
+
+                    node_has_unique[k] = false;
+
+                    mapper2_input inp;
+                    inp.T = &T;
+                    inp.node = bfs[k];
+                    inp.missing_sample_mutations =
+                        &pruned_sample.sample_mutations;
+                    inp.excess_mutations = &node_excess_mutations[k];
+                    inp.imputed_mutations = &imputed_mutations[k];
+                    inp.best_node_num_leaves = &best_node_num_leaves;
+                    inp.best_set_difference = &best_set_difference;
+                    inp.best_node = &best_node;
+                    inp.best_j = &best_j;
+                    inp.num_best = &num_best;
+                    inp.j = k;
+                    inp.has_unique = &best_node_has_unique;
+
+                    inp.set_difference = &node_set_difference[k];
+
+                    inp.distance = node_distance[k];
+                    inp.best_distance = &best_distance;
+
+                    inp.best_j_vec = &best_j_vec;
+                    inp.node_has_unique = &(node_has_unique);
+
+                    mapper2_body(inp, true);
+                }
+            },
+            ap);*/
+        //==== new mapper
+        Ripples_Mapper_Output_Interface mapper_out;
+        ripples_mapper(pruned_sample,mapper_out,dfs,T.root);
+        //==== END new mapper
+        std::vector<Recomb_Interval> valid_pairs;
+        bool has_recomb = false;
+
+        size_t at = 0;
+        for (size_t i = 0; i < num_mutations; i++) {
+            for (size_t j = i; j < num_mutations; j++) {
+                fprintf(stderr, "\rTrying %zu of %zu breakpoint pairs.", ++at,
+                        num_mutations * (1 + num_mutations) / 2);
+                Pruned_Sample donor("donor");
+                Pruned_Sample acceptor("acceptor");
+
+                donor.sample_mutations.clear();
+                acceptor.sample_mutations.clear();
+
+                for (size_t k = 0; k < num_mutations; k++) {
+                    if ((k >= i) && (k < j)) {
+                        donor.add_mutation(pruned_sample.sample_mutations[k]);
+                    } else {
+                        acceptor.add_mutation(
+                            pruned_sample.sample_mutations[k]);
+                    }
+                }
+
+                int start_range_high =
+                    pruned_sample.sample_mutations[i].position;
+                int start_range_low =
+                    (i >= 1) ? pruned_sample.sample_mutations[i - 1].position
+                             : 0;
+
+                // int end_range_high =
+                // pruned_sample.sample_mutations[j].position;
+                int end_range_high = 1e9;
+                int end_range_low =
+                    (j >= 1) ? pruned_sample.sample_mutations[j - 1].position
+                             : 0;
+
+                // int end_range_low =
+                // pruned_sample.sample_mutations[j].position; int end_range_high
+                // = (j+1<num_mutations) ?
+                // pruned_sample.sample_mutations[j+1].position : 1e9;
+
+                if ((donor.sample_mutations.size() < branch_len) ||
+                    (acceptor.sample_mutations.size() < branch_len) ||
+                    (end_range_low - start_range_high < min_range) ||
+                    (end_range_low - start_range_high > max_range)) {
+                    continue;
+                }
+
+                tbb::concurrent_vector<Recomb_Node> donor_nodes;
+                tbb::concurrent_vector<Recomb_Node> acceptor_nodes;
+
+                donor_nodes.clear();
+                acceptor_nodes.clear();
+                const auto node_to_consider=T.get_node(nid_to_consider);
+                const auto ignore_range_start=node_to_consider->dfs_idx;
+                const auto ignore_range_end=node_to_consider->dfs_end_idx-1;
+                // find acceptor(s)
+                {
+                    tbb::parallel_for(
+                        tbb::blocked_range<size_t>(0, total_nodes),
+                        [&](tbb::blocked_range<size_t> r) {
+                            for (size_t k = r.begin(); k < r.end(); ++k) {
+                                //=====Mapper_check
+                                auto curr_node_idx=bfs[k]->dfs_idx;
+                                if ((tree_num_leaves[bfs[k]] <
+                                     num_descendants) ||(curr_node_idx>=ignore_range_start&&curr_node_idx<=ignore_range_end)) {
+                                    continue;
+                                }
+                                auto first_half_mut=mapper_out.mut_count_out[i*node_size+curr_node_idx].count_before_exclusive();
+                                auto second_half_mut=mapper_out.mut_count_out[num_mutations*node_size+curr_node_idx].count_before_exclusive()-mapper_out.mut_count_out[(j-1)*node_size+curr_node_idx].count_before_inclusive();
+                                auto total=first_half_mut+second_half_mut;
+                                /*// Is placement as sibling
+                                size_t num_mut = 0;
+                                if (bfs[k]->is_leaf() || node_has_unique[k]) {
+                                    std::vector<MAT::Mutation> l2_mut;
+
+                                    // Compute l2_mut
+                                    for (auto m1 : node_excess_mutations[k]) {
+                                        bool found = false;
+                                        for (auto m2 : bfs[k]->mutations) {
+                                            if (m1.is_masked()) {
+                                                break;
+                                            }
+                                            if (m1.position == m2.position) {
+                                                if (m1.mut_nuc == m2.mut_nuc) {
+                                                    found = true;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        if (!found) {
+                                            if ((m1.position <
+                                                 start_range_high) ||
+                                                (m1.position > end_range_low)) {
+                                                num_mut++;
+                                            }
+                                        }
+                                        if (num_mut + parsimony_improvement >
+                                            (size_t)orig_parsimony) {
+                                            //== mapper check
+                                            if(total<num_mut){
+                                                fprintf(stderr,"mut count mismatch got %ld, expect %ld ot more\n",total,num_mut);
+                                                raise(SIGTRAP);
+                                            }
+                                            break;
+                                        }
+                                    }
+
+                                    if (num_mut + parsimony_improvement <=
+                                        (size_t)orig_parsimony) {
+                                        if(total!=num_mut){
+                                            fprintf(stderr,"mut count mismatch got %ld, expect %ld\n",total,num_mut);
+                                            raise(SIGTRAP);
+                                        }
+                                        acceptor_nodes.emplace_back(
+                                            Recomb_Node(bfs[k]->identifier,
+                                                        node_set_difference[k],
+                                                        num_mut, 'y'));
+                                    }
+                                    /*if(!mapper_out.is_sibling[curr_node_idx]){
+                                        fprintf(stderr,"should be sibling\n");
+                                        raise(SIGTRAP);
+                                    }*-/
+                                }
+                                // Else placement as child
+                                else {
+                                    for (auto m1 : node_excess_mutations[k]) {
+                                        bool found = false;
+                                        for (auto m2 : bfs[k]->mutations) {
+                                            if (m1.is_masked()) {
+                                                break;
+                                            }
+                                            if (m1.position == m2.position) {
+                                                if (m1.mut_nuc == m2.mut_nuc) {
+                                                    found = true;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        if (!found) {
+                                            if ((m1.position <
+                                                 start_range_high) ||
+                                                (m1.position > end_range_low)) {
+                                                num_mut++;
+                                            }
+                                        }
+                                        if (num_mut + parsimony_improvement >
+                                            (size_t)orig_parsimony) {
+                                                   if(total<num_mut){
+                                                fprintf(stderr,"mut count mismatch got %ld, expect %ld ot more\n",total,num_mut);
+                                                raise(SIGTRAP);
+                                            }
+                                            break;
+                                        }
+                                    }
+
+                                    if (num_mut + parsimony_improvement <=
+                                        (size_t)orig_parsimony) {
+                                        if(total!=num_mut){
+                                            fprintf(stderr,"mut count mismatch got %ld, expect %ld\n",total,num_mut);
+                                            raise(SIGTRAP);
+                                        }
+                                        acceptor_nodes.emplace_back(
+                                            Recomb_Node(bfs[k]->identifier,
+                                                        node_set_difference[k],
+                                                        num_mut, 'n'));
+                                    }
+                                    /*if(mapper_out.is_sibling[curr_node_idx]){
+                                        fprintf(stderr,"should not be sibling\n");
+                                        raise(SIGTRAP);
+                                    }*-/
+                                }*/
+                                 if (total + parsimony_improvement <=
+                                        (size_t)orig_parsimony) {
+                                        if(bfs[k]->identifier=="node_100005"){
+                                            //fprintf(stderr,"%d\n",mapper_out.mut_count_out[node_size*num_mutations+curr_node_idx].count_before_exclusive());
+                                        }
+                                        acceptor_nodes.emplace_back(
+                                            Recomb_Node(bfs[k]->identifier,
+                                                        mapper_out.mut_count_out[node_size*num_mutations+curr_node_idx].count_before_exclusive()+mapper_out.is_sibling[idx],
+                                                        total, 'n'));
+                                }
+                            }
+                        },
+                        ap);
+                }
+
+                if (acceptor_nodes.size() == 0) {
+                    continue;
+                }
+
+                // find donor(s)
+                {
+                    tbb::parallel_for(
+                        tbb::blocked_range<size_t>(0, total_nodes),
+                        [&](tbb::blocked_range<size_t> r) {
+                            for (size_t k = r.begin(); k < r.end(); ++k) {
+                                //=====Mapper_check
+                                auto curr_node_idx=bfs[k]->dfs_idx;
+                                
+                                if ((tree_num_leaves[bfs[k]] <
+                                     num_descendants) ||
+                                    (curr_node_idx>=ignore_range_start&&curr_node_idx<=ignore_range_end)) {
+                                    continue;
+                                }
+                                auto total=mapper_out.mut_count_out[(j-1)*node_size+curr_node_idx].count_before_inclusive()-(mapper_out.mut_count_out[i*node_size+curr_node_idx].count_before_exclusive());
+                                /*
+                                size_t num_mut = 0;
+
+                                // Is placement as sibling
+                                if (bfs[k]->is_leaf() || node_has_unique[k]) {
+                                    std::vector<MAT::Mutation> l2_mut;
+
+                                    // Compute l2_mut
+                                    for (auto m1 : node_excess_mutations[k]) {
+                                        bool found = false;
+                                        for (auto m2 : bfs[k]->mutations) {
+                                            if (m1.is_masked()) {
+                                                break;
+                                            }
+                                            if (m1.position == m2.position) {
+                                                if (m1.mut_nuc == m2.mut_nuc) {
+                                                    found = true;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        if (!found) {
+                                            if ((m1.position >=
+                                                 start_range_high) &&
+                                                (m1.position <=
+                                                 end_range_low)) {
+                                                num_mut++;
+                                            }
+                                        }
+
+                                        if (num_mut + parsimony_improvement >
+                                            (size_t)orig_parsimony) {
+                                                //== mapper check
+                                            if(total<num_mut){
+                                                fprintf(stderr,"mut count mismatch got %d, expect %d ot more\n",total,num_mut);
+                                                raise(SIGTRAP);
+                                            }
+                                            break;
+                                        }
+                                    }
+
+                                    if (num_mut + parsimony_improvement <=
+                                        (size_t)orig_parsimony) {
+                                        if(total!=num_mut){
+                                            fprintf(stderr,"mut count mismatch got %d, expect %d\n",total,num_mut);
+                                            raise(SIGTRAP);
+                                        }
+                                        donor_nodes.emplace_back(
+                                            Recomb_Node(bfs[k]->identifier,
+                                                        node_set_difference[k],
+                                                        num_mut, 'y'));
+                                    }
+                                    /*if(!mapper_out.is_sibling[curr_node_idx]){
+                                        fprintf(stderr,"should be sibling\n");
+                                        raise(SIGTRAP);
+                                    }*-/
+                                }
+                                // Else placement as child
+                                else {
+                                    for (auto m1 : node_excess_mutations[k]) {
+                                        bool found = false;
+                                        for (auto m2 : bfs[k]->mutations) {
+                                            if (m1.is_masked()) {
+                                                break;
+                                            }
+                                            if (m1.position == m2.position) {
+                                                if (m1.mut_nuc == m2.mut_nuc) {
+                                                    found = true;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        if (!found) {
+                                            if ((m1.position >=
+                                                 start_range_high) &&
+                                                (m1.position <=
+                                                 end_range_low)) {
+                                                num_mut++;
+                                            }
+                                        }
+                                        if (num_mut + parsimony_improvement >
+                                            (size_t)orig_parsimony) {
+                                                //== mapper check
+                                            if(total<num_mut){
+                                                fprintf(stderr,"mut count mismatch got %d, expect %d ot more\n",total,num_mut);
+                                                raise(SIGTRAP);
+                                            }
+                                            break;
+                                        }
+                                    }
+
+                                    if (num_mut + parsimony_improvement <=
+                                        (size_t)orig_parsimony) {
+                                                                                    if(total!=num_mut){
+                                            fprintf(stderr,"mut count mismatch got %d, expect %d\n",total,num_mut);
+                                            raise(SIGTRAP);
+                                        }
+                                        donor_nodes.emplace_back(
+                                            Recomb_Node(bfs[k]->identifier,
+                                                        node_set_difference[k],
+                                                        num_mut, 'n'));
+                                    }
+                                    /*if(mapper_out.is_sibling[curr_node_idx]){
+                                        fprintf(stderr,"should not be sibling\n");
+                                        raise(SIGTRAP);
+                                    }*-/
+                                }*/
+                                if (total + parsimony_improvement <=
+                                        (size_t)orig_parsimony) {
+                                        donor_nodes.emplace_back(
+                                            Recomb_Node(bfs[k]->identifier,
+                                                        mapper_out.mut_count_out[node_size*num_mutations+curr_node_idx].count_before_exclusive()+mapper_out.is_sibling[idx],
+                                                        total, 'n'));
+                                }
+                            }
+                        },
+                        ap);
+                }
+
+                tbb::parallel_sort(donor_nodes.begin(), donor_nodes.end());
+                tbb::parallel_sort(acceptor_nodes.begin(),
+                                   acceptor_nodes.end());
+
+                if (donor_nodes.size() > 1000) {
+                    donor_nodes.resize(1000);
+                }
+
+                if (acceptor_nodes.size() > 1000) {
+                    acceptor_nodes.resize(1000);
+                }
+
+                // to print any pair of breakpoint interval exactly once for
+                // multiple donor-acceptor pairs
+                bool has_printed = false;
+
+                for (auto d : donor_nodes) {
+                    if (T.is_ancestor(nid_to_consider, d.name)) {
+                        continue;
+                    }
+                    for (auto a : acceptor_nodes) {
+                        if (T.is_ancestor(nid_to_consider, a.name)) {
+                            continue;
+                        }
+                        // Ensure donor and acceptor are not the same and
+                        // neither of them is a descendant of the recombinant
+                        // node total parsimony is less than the maximum allowed
+                        if ((d.name != a.name) && (d.name != nid_to_consider) &&
+                            (a.name != nid_to_consider) &&
+                            //(!T.is_ancestor(nid_to_consider,d.name)) &&
+                            //(!T.is_ancestor(nid_to_consider,a.name)) &&
+                            (orig_parsimony >= d.parsimony + a.parsimony +
+                                                   parsimony_improvement)) {
+                            Pruned_Sample donor("curr-donor");
+                            donor.sample_mutations.clear();
+                            acceptor.sample_mutations.clear();
+
+                            for (auto anc : T.rsearch(d.name, true)) {
+                                for (auto mut : anc->mutations) {
+                                    donor.add_mutation(mut);
+                                }
+                            }
+
+                            for (auto mut : donor.sample_mutations) {
+                                if ((mut.position > start_range_low) &&
+                                    (mut.position <= start_range_high)) {
+                                    bool in_pruned_sample = false;
+                                    for (auto mut2 :
+                                         pruned_sample.sample_mutations) {
+                                        if (mut.position == mut2.position) {
+                                            in_pruned_sample = true;
+                                        }
+                                    }
+                                    if (!in_pruned_sample) {
+                                        start_range_low = mut.position;
+                                    }
+                                }
+                                if ((mut.position > end_range_low) &&
+                                    (mut.position <= end_range_high)) {
+                                    bool in_pruned_sample = false;
+                                    for (auto mut2 :
+                                         pruned_sample.sample_mutations) {
+                                        if (mut.position == mut2.position) {
+                                            in_pruned_sample = true;
+                                        }
+                                    }
+                                    if (!in_pruned_sample) {
+                                        end_range_high = mut.position;
+                                    }
+                                }
+                            }
+
+                            for (auto mut : pruned_sample.sample_mutations) {
+                                if ((mut.position > start_range_low) &&
+                                    (mut.position <= start_range_high)) {
+                                    bool in_pruned_sample = false;
+                                    for (auto mut2 : donor.sample_mutations) {
+                                        if (mut.position == mut2.position) {
+                                            in_pruned_sample = true;
+                                        }
+                                    }
+                                    if (!in_pruned_sample) {
+                                        start_range_low = mut.position;
+                                    }
+                                }
+                                if ((mut.position > end_range_low) &&
+                                    (mut.position <= end_range_high)) {
+                                    bool in_pruned_sample = false;
+                                    for (auto mut2 : donor.sample_mutations) {
+                                        if (mut.position == mut2.position) {
+                                            in_pruned_sample = true;
+                                        }
+                                    }
+                                    if (!in_pruned_sample) {
+                                        end_range_high = mut.position;
+                                    }
+                                }
+                            }
+
+                            // tbb_lock.lock();
+                            valid_pairs.push_back(Recomb_Interval(
+                                d, a, start_range_low, start_range_high,
+                                end_range_low, end_range_high));
+                            // tbb_lock.unlock();
+
+                            has_recomb = true;
+                            has_printed = true;
+                            break;
+                        }
+                    }
+                    if (has_printed) {
+                        break;
+                    }
+                }
+            }
+        }
+        fprintf(stderr, "\n");
+
+        valid_pairs = combine_intervals(valid_pairs);
+        // print combined pairs
+        for (auto p : valid_pairs) {
+            std::string end_range_high_str =
+                (p.end_range_high == 1e9) ? "GENOME_SIZE"
+                                          : std::to_string(p.end_range_high);
+            fprintf(
+                recomb_file,
+                "%s\t(%i,%i)\t(%i,%s)\t%s\t%c\t%i\t%s\t%c\t%i\t%i\t%i\t%i\n",
+                nid_to_consider.c_str(), p.start_range_low, p.start_range_high,
+                p.end_range_low, end_range_high_str.c_str(), p.d.name.c_str(),
+                p.d.is_sibling, p.d.node_parsimony, p.a.name.c_str(),
+                p.a.is_sibling, p.a.node_parsimony, orig_parsimony,
+                std::min(
+                    {orig_parsimony, p.d.node_parsimony, p.a.node_parsimony}),
+                p.d.parsimony + p.a.parsimony);
+            fflush(recomb_file);
+        }
+
+        if (has_recomb) {
+            fprintf(desc_file, "%s\t", nid_to_consider.c_str());
+            for (auto l : T.get_leaves(nid_to_consider)) {
+                fprintf(desc_file, "%s,", l->identifier.c_str());
+            }
+            fprintf(desc_file, "\n");
+            fflush(desc_file);
+            fprintf(stderr, "Done %zu/%zu branches [RECOMBINATION FOUND!]\n\n",
+                    ++num_done, nodes_to_consider.size());
+        } else {
+            fprintf(stderr, "Done %zu/%zu branches\n\n", ++num_done,
+                    nodes_to_consider.size());
+        }
+    }
+
+    fclose(desc_file);
+    fclose(recomb_file);
+
+    fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
+}

--- a/src/ripples/ripples_fast/main.cpp
+++ b/src/ripples/ripples_fast/main.cpp
@@ -164,13 +164,26 @@ int main(int argc, char **argv) {
     fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
 
     timer.Start();
-    std::vector<size_t> nodes_to_seach;
+    std::vector<MAT::Node*> nodes_to_seach;
     nodes_to_seach.reserve(dfs.size());
     for (auto &node : dfs) {
         if ((node->dfs_end_idx - node->dfs_idx) >= num_descendants) {
-            nodes_to_seach.push_back(node->dfs_idx);
+            nodes_to_seach.push_back(node);
         }
     }
+    std::vector<int> index_map;
+    int node_to_search_idx=0;
+    index_map.reserve(dfs.size());
+    for (int dfs_idx = 0; dfs_idx <(int) dfs.size(); dfs_idx++)
+    {
+        if (node_to_search_idx!=nodes_to_seach.size()&&nodes_to_seach[node_to_search_idx]->dfs_idx==dfs_idx){
+            index_map.push_back(node_to_search_idx);
+            node_to_search_idx++;
+        }else{
+            index_map.push_back(-node_to_search_idx);
+        }
+    }
+    
     fprintf(stderr, "%zu out of %zu nodes have enough descendant to be donor/acceptor",nodes_to_seach.size(),dfs.size());
     size_t s = 0, e = nodes_to_consider.size();
 
@@ -208,10 +221,10 @@ int main(int argc, char **argv) {
 
         //==== new mapper
         Ripples_Mapper_Output_Interface mapper_out;
-        ripples_mapper(pruned_sample, mapper_out, dfs, T.root);
+        ripples_mapper(pruned_sample, mapper_out, nodes_to_seach.size(),index_map, T.root);
         //==== END new mapper
         tbb::concurrent_vector<Recomb_Interval> valid_pairs_con;
-        ripplrs_merger(pruned_sample, nodes_to_seach, dfs, node_size,
+        ripplrs_merger(pruned_sample, index_map,nodes_to_seach , nodes_to_seach.size(),
                        orig_parsimony - parsimony_improvement, T,
                        valid_pairs_con, mapper_out, num_threads, branch_len,
                        min_range, max_range);

--- a/src/ripples/ripples_fast/main.cpp
+++ b/src/ripples/ripples_fast/main.cpp
@@ -99,10 +99,10 @@ int main(int argc, char **argv) {
                         words[0].c_str());
                 exit(1);
             } else {
-                /*for (auto anc : T.rsearch(n->identifier, true)) {
-                    nodes_to_consider.insert(anc->identifier);
-                }*/
-                nodes_to_consider.insert(n);
+                for (auto anc : T.rsearch(n->identifier, true)) {
+                    nodes_to_consider.insert(anc);
+                }
+                //nodes_to_consider.insert(n);
             }
         }
         infile.close();
@@ -234,16 +234,18 @@ int main(int argc, char **argv) {
             std::string end_range_high_str =
                 (p.end_range_high == 1e9) ? "GENOME_SIZE"
                                           : std::to_string(p.end_range_high);
+            auto donor_adj_parsimony=p.d.node_parsimony+!p.d.is_sibling;
+            auto acceptor_adj_parsimony=p.a.node_parsimony+!p.a.is_sibling;
             fprintf(
                 recomb_file,
                 "%s\t(%i,%i)\t(%i,%s)\t%s\t%c\t%i\t%s\t%c\t%i\t%i\t%i\t%i\n",
                 node_to_consider->identifier.c_str(), p.start_range_low,
                 p.start_range_high, p.end_range_low, end_range_high_str.c_str(),
-                p.d.node->identifier.c_str(), p.d.is_sibling,
-                p.d.node_parsimony, p.a.node->identifier.c_str(),
-                p.a.is_sibling, p.a.node_parsimony, orig_parsimony,
+                p.d.node->identifier.c_str(), p.d.is_sibling?'y':'n',
+                donor_adj_parsimony, p.a.node->identifier.c_str(),
+                p.a.is_sibling?'y':'n', acceptor_adj_parsimony, orig_parsimony,
                 std::min(
-                    {orig_parsimony, p.d.node_parsimony, p.a.node_parsimony}),
+                    {orig_parsimony, donor_adj_parsimony, acceptor_adj_parsimony}),
                 p.d.parsimony + p.a.parsimony);
             fflush(recomb_file);
         }

--- a/src/ripples/ripples_fast/main.cpp
+++ b/src/ripples/ripples_fast/main.cpp
@@ -174,6 +174,7 @@ int main(int argc, char **argv) {
             e - s);
 
     size_t num_done = 0;
+    FILE* before_joining_fh=fopen("before_join_test","w");
     auto node_size = dfs.size();
     for (size_t idx = s; idx < e; idx++) {
         auto node_to_consider = nodes_to_consider_vec[idx];
@@ -202,6 +203,16 @@ int main(int argc, char **argv) {
                        valid_pairs_con, mapper_out, num_threads, branch_len,
                        min_range, max_range);
         std::vector<Recomb_Interval> temp(std::vector<Recomb_Interval>(valid_pairs_con.begin(),valid_pairs_con.end()));
+        for(auto p: temp) {
+            std::string end_range_high_str = (p.end_range_high == 1e9) ? "GENOME_SIZE" : std::to_string(p.end_range_high);
+                        fprintf(
+                before_joining_fh,
+                "%s\t(%i,%i)\t(%i,%s)\t%s\t%s\n",
+                node_to_consider->identifier.c_str(), p.start_range_low,
+                p.start_range_high, p.end_range_low, end_range_high_str.c_str(),
+                p.d.node->identifier.c_str(), p.a.node->identifier.c_str());
+            fflush(before_joining_fh);
+        }
         std::vector<Recomb_Interval> valid_pairs = combine_intervals(temp);
         // print combined pairs
         for (auto p : valid_pairs) {

--- a/src/ripples/ripples_fast/main.cpp
+++ b/src/ripples/ripples_fast/main.cpp
@@ -26,7 +26,7 @@ struct idx_eq{
 }
 struct interval_sorter{
     bool operator()(Recomb_Interval& a,Recomb_Interval& b){
-        if (a.end_range_high<b.start_range_high)
+        if (a.start_range_high<b.start_range_high)
         {
             return true;
         }else if(a.start_range_high==b.start_range_high&&a.end_range_low<b.end_range_low){

--- a/src/ripples/ripples_fast/ripple_aux.cpp
+++ b/src/ripples/ripples_fast/ripple_aux.cpp
@@ -1,0 +1,117 @@
+#include "ripples.hpp"
+
+void Pruned_Sample::add_mutation(MAT::Mutation mut) {
+    // If not reversal to reference allele
+    if ((mut.ref_nuc != mut.mut_nuc) &&
+        (positions.find(mut.position) == positions.end())) {
+        auto iter = std::lower_bound(sample_mutations.begin(),
+                                     sample_mutations.end(), mut);
+        auto m = mut.copy();
+        m.par_nuc = m.ref_nuc;
+        sample_mutations.insert(iter, m);
+    }
+    positions.insert(mut.position);
+}
+Pruned_Sample::Pruned_Sample(std::string name) {
+    sample_name = name;
+    sample_mutations.clear();
+    positions.clear();
+}
+
+std::vector<Recomb_Interval>
+combine_intervals(std::vector<Recomb_Interval> pair_list) {
+    // combine second interval
+    std::vector<Recomb_Interval> pairs(pair_list);
+    std::sort(pairs.begin(),
+              pairs.end()); // sorts by beginning of second interval
+    for (size_t i = 0; i < pairs.size(); i++) {
+        for (size_t j = i + 1; j < pairs.size(); j++) {
+            // check everything except first interval is same and first interval
+            // of pairs[i] ends where it starts for pairs[j]
+            if ((pairs[i].d.name == pairs[j].d.name) &&
+                (pairs[i].a.name == pairs[j].a.name) &&
+                (pairs[i].start_range_low == pairs[j].start_range_low) &&
+                (pairs[i].start_range_high == pairs[j].start_range_high) &&
+                (pairs[i].end_range_high == pairs[j].end_range_low) &&
+                ((pairs[i].d.parsimony + pairs[i].a.parsimony) ==
+                 (pairs[j].d.parsimony + pairs[j].a.parsimony))) {
+                pairs[i].end_range_high = pairs[j].end_range_high;
+                pairs.erase(pairs.begin() + j); // remove the combined element
+                j--;
+            }
+        }
+    }
+    // combine first interval
+    std::sort(pairs.begin(), pairs.end(), Comp_First_Interval());
+    for (size_t i = 0; i < pairs.size(); i++) {
+        for (size_t j = i + 1; j < pairs.size(); j++) {
+            // check everything except second interval is same and second
+            // interval of pairs[i] ends where it starts for pairs[j]
+            if ((pairs[i].d.name == pairs[j].d.name) &&
+                (pairs[i].a.name == pairs[j].a.name) &&
+                (pairs[i].end_range_low == pairs[j].end_range_low) &&
+                (pairs[i].end_range_high == pairs[j].end_range_high) &&
+                (pairs[i].start_range_high == pairs[j].start_range_low) &&
+                ((pairs[i].d.parsimony + pairs[i].a.parsimony) ==
+                 (pairs[j].d.parsimony + pairs[j].a.parsimony))) {
+                pairs[i].start_range_high = pairs[j].start_range_high;
+                pairs.erase(pairs.begin() + j);
+                j--;
+            }
+        }
+    }
+    return pairs;
+}
+po::variables_map check_options(int argc, char **argv) {
+    uint32_t num_cores = tbb::task_scheduler_init::default_num_threads();
+    std::string num_threads_message = "Number of threads to use when possible "
+                                      "[DEFAULT uses all available cores, " +
+                                      std::to_string(num_cores) +
+                                      " detected on this machine]";
+
+    po::options_description desc("optimize options");
+    desc.add_options()    
+    ("input-mat,i", po::value<std::string>()->required(),
+     "Input mutation-annotated tree file to optimize [REQUIRED].")
+    ("branch-length,l", po::value<uint32_t>()->default_value(3), \
+     "Minimum length of the branch to consider to recombination events")
+    ("min-coordinate-range,r", po::value<int>()->default_value(1e3), \
+     "Minimum range of the genomic coordinates of the mutations on the recombinant branch")
+    ("max-coordinate-range,R", po::value<int>()->default_value(1e7), \
+     "Maximum range of the genomic coordinates of the mutations on the recombinant branch")
+    ("outdir,d", po::value<std::string>()->default_value("."),
+     "Output directory to dump output files [DEFAULT uses current directory]")
+    ("samples-filename,s", po::value<std::string>()->default_value(""),
+     "Restrict the search to the ancestors of the samples specified in the input file")
+
+    ("parsimony-improvement,p", po::value<int>()->default_value(3), \
+     "Minimum improvement in parsimony score of the recombinant sequence during the partial placement")
+    ("num-descendants,n", po::value<uint32_t>()->default_value(10), \
+     "Minimum number of leaves that node should have to be considered for recombination.")
+    ("threads,T", po::value<uint32_t>()->default_value(num_cores), num_threads_message.c_str())
+    ("start-index,S", po::value<int>()->default_value(-1), "start index [EXPERIMENTAL]")
+    ("end-index,E", po::value<int>()->default_value(-1), "end index [EXPERIMENTAL]")
+    ("help,h", "Print help messages");
+
+    po::options_description all_options;
+    all_options.add(desc);
+    po::positional_options_description p;
+    po::variables_map vm;
+    try {
+        po::store(po::command_line_parser(argc, argv)
+                      .options(all_options)
+                      .positional(p)
+                      .run(),
+                  vm);
+        po::notify(vm);
+    } catch (std::exception &e) {
+        std::cerr << desc << std::endl;
+        // Return with error code 1 unless
+        // the user specifies help
+        if (vm.count("help"))
+            exit(0);
+        else
+            exit(1);
+    }
+    return vm;
+}

--- a/src/ripples/ripples_fast/ripple_aux.cpp
+++ b/src/ripples/ripples_fast/ripple_aux.cpp
@@ -12,7 +12,7 @@ void Pruned_Sample::add_mutation(MAT::Mutation mut) {
     }
     positions.insert(mut.position);
 }
-Pruned_Sample::Pruned_Sample(std::string name) {
+Pruned_Sample::Pruned_Sample(MAT::Node* name) {
     sample_name = name;
     sample_mutations.clear();
     positions.clear();
@@ -28,8 +28,8 @@ combine_intervals(std::vector<Recomb_Interval> pair_list) {
         for (size_t j = i + 1; j < pairs.size(); j++) {
             // check everything except first interval is same and first interval
             // of pairs[i] ends where it starts for pairs[j]
-            if ((pairs[i].d.name == pairs[j].d.name) &&
-                (pairs[i].a.name == pairs[j].a.name) &&
+            if ((pairs[i].d.node->identifier == pairs[j].d.node->identifier) &&
+                (pairs[i].a.node->identifier == pairs[j].a.node->identifier) &&
                 (pairs[i].start_range_low == pairs[j].start_range_low) &&
                 (pairs[i].start_range_high == pairs[j].start_range_high) &&
                 (pairs[i].end_range_high == pairs[j].end_range_low) &&
@@ -47,8 +47,8 @@ combine_intervals(std::vector<Recomb_Interval> pair_list) {
         for (size_t j = i + 1; j < pairs.size(); j++) {
             // check everything except second interval is same and second
             // interval of pairs[i] ends where it starts for pairs[j]
-            if ((pairs[i].d.name == pairs[j].d.name) &&
-                (pairs[i].a.name == pairs[j].a.name) &&
+            if ((pairs[i].d.node->identifier == pairs[j].d.node->identifier) &&
+                (pairs[i].a.node->identifier == pairs[j].a.node->identifier) &&
                 (pairs[i].end_range_low == pairs[j].end_range_low) &&
                 (pairs[i].end_range_high == pairs[j].end_range_high) &&
                 (pairs[i].start_range_high == pairs[j].start_range_low) &&

--- a/src/ripples/ripples_fast/ripple_merger.cpp
+++ b/src/ripples/ripples_fast/ripple_merger.cpp
@@ -1,0 +1,5 @@
+#include "ripples.hpp"
+
+static void find_par_lower(Mut_Count_Out_t& counts, size_t lower_nuc,size_t upper_nuc){
+
+}

--- a/src/ripples/ripples_fast/ripple_merger.cpp
+++ b/src/ripples/ripples_fast/ripple_merger.cpp
@@ -1,5 +1,333 @@
 #include "ripples.hpp"
+struct acceptor {
+    int operator()(const Mut_Count_Out_t &counts, size_t i, size_t j,
+                   size_t curr_node_idx, size_t node_size,
+                   size_t num_mutations) {
+        auto first_half_mut =
+            counts[i * node_size + curr_node_idx].count_before_exclusive();
+        auto second_half_mut = counts[num_mutations * node_size + curr_node_idx]
+                                   .count_before_exclusive() -
+                               counts[(j - 1) * node_size + curr_node_idx]
+                                   .count_before_inclusive();
+        return first_half_mut + second_half_mut;
+    }
+};
+struct donor {
+    int operator()(const Mut_Count_Out_t &counts, size_t i, size_t j,
+                   size_t curr_node_idx, size_t node_size,
+                   size_t num_mutations) {
+        return counts[(j - 1) * node_size + curr_node_idx]
+                   .count_before_inclusive() -
+               (counts[i * node_size + curr_node_idx].count_before_exclusive());
+    }
+};
 
-static void find_par_lower(Mut_Count_Out_t& counts, size_t lower_nuc,size_t upper_nuc){
+template <typename T>
+static int filter(const Ripples_Mapper_Output_Interface &out_ifc, size_t i,
+                  size_t j, size_t node_size, size_t num_mutations,
+                  std::vector<size_t>::const_iterator nodes_to_search_start,
+                  std::vector<size_t>::const_iterator nodes_to_search_end,
+                  std::vector<Recomb_Node> &filtered, int pasimony_threshold,
+                  const std::vector<MAT::Node*> dfs,
+                  T donor_or_acceptor) {
+    int min_par = pasimony_threshold + 1;
+    const auto& counts = out_ifc.mut_count_out;
+    for (; nodes_to_search_start < nodes_to_search_end;
+         nodes_to_search_start++) {
+        auto node_idx = *nodes_to_search_start;
+        auto this_par =
+            donor_or_acceptor(counts, i, j, node_idx, node_size, num_mutations);
+        if (this_par <= pasimony_threshold) {
+            min_par = std::min(min_par, this_par);
+            filtered.emplace_back(dfs[node_idx],
+                                  counts[node_size * num_mutations + node_idx]
+                                      .count_before_exclusive(),
+                                  this_par, out_ifc.is_sibling[node_idx]);
+        }
+    }
+    return min_par;
+}
+static void threshold_parsimony(std::vector<Recomb_Node> &donor_filtered,
+                                int pasimony_threshold) {
+    auto end_iter = donor_filtered.end();
+    auto start_iter = donor_filtered.begin();
+    while (start_iter != end_iter) {
+        if (start_iter->parsimony > pasimony_threshold) {
+            *start_iter = *(end_iter - 1);
+            end_iter--;
+        } else {
+            start_iter++;
+        }
+    }
+    donor_filtered.erase(end_iter, donor_filtered.end());
+}
 
+static void find_pairs(
+    const std::vector<Recomb_Node> &donor_nodes,
+    const std::vector<Recomb_Node> &acceptor_nodes,
+    const std::vector<MAT::Mutation> &pruned_sample_mutations, int i, int j,
+    int parsimony_threshold, const std::vector<MAT::Node *> &dfs_ordered_nodes,
+    const MAT::Tree &T, tbb::concurrent_vector<Recomb_Interval> &valid_pairs) {
+    bool has_printed = false;
+
+    for (auto d : donor_nodes) {
+        /*if (T.is_ancestor(nid_to_consider, d.name)) {
+            //raise(SIGTRAP);
+            continue;
+        }*/
+        for (auto a : acceptor_nodes) {
+            /*if (T.is_ancestor(nid_to_consider, a.name)) {
+                //raise(SIGTRAP);
+                continue;
+            }*/
+            // Ensure donor and acceptor are not the same and
+            // neither of them is a descendant of the recombinant
+            // node total parsimony is less than the maximum allowed
+            if (parsimony_threshold < d.parsimony + a.parsimony) {
+                break;
+            }
+            if ((d.node != a.node) 
+                        /*&& (d.name != nid_to_consider) &&
+                            (a.name != nid_to_consider) &&
+                            (orig_parsimony >= d.parsimony + a.parsimony +
+                                                   parsimony_improvement)
+                                                   */) {
+                int start_range_high = pruned_sample_mutations[i].position;
+                int start_range_low =
+                    (i >= 1) ? pruned_sample_mutations[i - 1].position : 0;
+
+                // int end_range_high = pruned_sample_mutations[j].position;
+                int end_range_high = 1e9;
+                int end_range_low =
+                    (j >= 1) ? pruned_sample_mutations[j - 1].position : 0;
+                Pruned_Sample donor;
+                donor.sample_mutations.clear();
+                Pruned_Sample acceptor;
+                acceptor.sample_mutations.clear();
+
+                auto donor_node = d.node;
+
+                for (auto anc : T.rsearch(donor_node->identifier, true)) {
+                    for (auto mut : anc->mutations) {
+                        donor.add_mutation(mut);
+                    }
+                }
+
+                for (auto mut : donor.sample_mutations) {
+                    if ((mut.position > start_range_low) &&
+                        (mut.position <= start_range_high)) {
+                        bool in_pruned_sample = false;
+                        for (auto mut2 : pruned_sample_mutations) {
+                            if (mut.position == mut2.position) {
+                                in_pruned_sample = true;
+                            }
+                        }
+                        if (!in_pruned_sample) {
+                            start_range_low = mut.position;
+                        }
+                    }
+                    if ((mut.position > end_range_low) &&
+                        (mut.position <= end_range_high)) {
+                        bool in_pruned_sample = false;
+                        for (auto mut2 : pruned_sample_mutations) {
+                            if (mut.position == mut2.position) {
+                                in_pruned_sample = true;
+                            }
+                        }
+                        if (!in_pruned_sample) {
+                            end_range_high = mut.position;
+                        }
+                    }
+                }
+
+                for (auto mut : pruned_sample_mutations) {
+                    if ((mut.position > start_range_low) &&
+                        (mut.position <= start_range_high)) {
+                        bool in_pruned_sample = false;
+                        for (auto mut2 : donor.sample_mutations) {
+                            if (mut.position == mut2.position) {
+                                in_pruned_sample = true;
+                            }
+                        }
+                        if (!in_pruned_sample) {
+                            start_range_low = mut.position;
+                        }
+                    }
+                    if ((mut.position > end_range_low) &&
+                        (mut.position <= end_range_high)) {
+                        bool in_pruned_sample = false;
+                        for (auto mut2 : donor.sample_mutations) {
+                            if (mut.position == mut2.position) {
+                                in_pruned_sample = true;
+                            }
+                        }
+                        if (!in_pruned_sample) {
+                            end_range_high = mut.position;
+                        }
+                    }
+                }
+
+                // tbb_lock.lock();
+                valid_pairs.push_back(
+                    Recomb_Interval(d, a, start_range_low, start_range_high,
+                                    end_range_low, end_range_high));
+                // tbb_lock.unlock();
+
+                has_printed = true;
+                break;
+            }
+        }
+        if (has_printed) {
+            break;
+        }
+    }
+}
+struct check_breakpoint {
+    const Ripples_Mapper_Output_Interface &out_ifc;
+    const std::vector<MAT::Mutation> &pruned_sample_mutations;
+    std::vector<size_t>::const_iterator nodes_to_search_start1;
+    std::vector<size_t>::const_iterator nodes_to_search_end1;
+    std::vector<size_t>::const_iterator nodes_to_search_start2;
+    std::vector<size_t>::const_iterator nodes_to_search_end2;
+    size_t node_size;
+    int pasimony_threshold;
+    const std::vector<MAT::Node *> &dfs_ordered_nodes;
+    const MAT::Tree &T;
+    tbb::concurrent_vector<Recomb_Interval> &valid_pairs;
+    void operator()(std::pair<int,int> in) const {
+        int i=in.first; int j=in.second;
+        if (i==10&&j==22)
+        {
+            //raise(SIGTRAP);
+        }
+        
+        std::vector<Recomb_Node> donor_filtered;
+        size_t num_mutations = pruned_sample_mutations.size();
+        int donor_min = filter(out_ifc, i, j, node_size, num_mutations,
+                               nodes_to_search_start1, nodes_to_search_end1,
+                               donor_filtered, pasimony_threshold,dfs_ordered_nodes, donor());
+        donor_min = std::min(
+            donor_min, filter(out_ifc, i, j, node_size, num_mutations,
+                              nodes_to_search_start2, nodes_to_search_end2,
+                              donor_filtered, pasimony_threshold,dfs_ordered_nodes, donor()));
+        if (donor_filtered.empty()) {
+            return;
+        }
+        int acceptor_threshold = pasimony_threshold - donor_min;
+        std::vector<Recomb_Node> acceptor_filtered;
+        int acceptor_min =
+            filter(out_ifc, i, j, node_size, num_mutations,
+                   nodes_to_search_start1, nodes_to_search_end1,
+                   acceptor_filtered, acceptor_threshold,dfs_ordered_nodes, acceptor());
+        acceptor_min =
+            std::min(acceptor_min,
+                     filter(out_ifc, i, j, node_size, num_mutations,
+                            nodes_to_search_start2, nodes_to_search_end2,
+                            acceptor_filtered, acceptor_threshold,dfs_ordered_nodes, acceptor()));
+        if (acceptor_filtered.empty()) {
+            return;
+        }
+        threshold_parsimony(donor_filtered, pasimony_threshold - acceptor_min);
+        if (donor_filtered.empty()) {
+            return;
+        }
+        std::sort(acceptor_filtered.begin(), acceptor_filtered.end());
+        std::sort(donor_filtered.begin(), donor_filtered.end());
+        find_pairs(donor_filtered, acceptor_filtered, pruned_sample_mutations,
+                   i, j, pasimony_threshold, dfs_ordered_nodes, T, valid_pairs);
+    }
+};
+
+struct search_position {
+    const std::vector<MAT::Mutation> &pruned_sample_mutations;
+    int &i;
+    int &j;
+    int branch_len;
+    int min_range;
+    int max_range;
+    int last_i;
+    bool is_j_end_of_range(int start_range_high, int total_size) const {
+        return j >= total_size || total_size - (j - i) < branch_len ||
+               pruned_sample_mutations[j-1].position - start_range_high >
+                   max_range;
+    }
+    std::pair<int, int> operator()(tbb::flow_control &fc) const {
+        int start_range_high;// = pruned_sample_mutations[i].position;
+        int total_size = pruned_sample_mutations.size();
+        // i end
+        if (i > last_i) {
+            fc.stop();
+            return std::make_pair(0, 0);
+        }
+        j++;
+        // j end
+        if (i!=-1)
+        {
+            start_range_high = pruned_sample_mutations[i].position;
+        }
+        
+        while (i==-1||is_j_end_of_range(start_range_high, total_size)) {
+            i++;
+            if (i > last_i) {
+                fc.stop();
+                return std::make_pair(0, 0);
+            }
+            start_range_high = pruned_sample_mutations[i].position;
+            j = i + branch_len;
+            while (j < total_size && pruned_sample_mutations[j - 1].position <
+                                         start_range_high + min_range) {
+                j++;
+            }
+        }
+        return std::make_pair(i, j);
+    }
+};
+
+void ripplrs_merger(const Pruned_Sample &pruned_sample,
+                    const std::vector<size_t> &nodes_to_search,
+                    std::vector<MAT::Node *> &dfs_ordered_nodes,
+                    size_t node_size, int pasimony_threshold,
+                    const MAT::Tree &T,
+                    tbb::concurrent_vector<Recomb_Interval> &valid_pairs,
+                    const Ripples_Mapper_Output_Interface &out_ifc,
+                    int nthreads, int branch_len, int min_range,
+                    int max_range) {
+    auto pruned_node = pruned_sample.sample_name;
+    std::vector<size_t>::const_iterator nodes_to_search_start1 =
+        nodes_to_search.begin();
+    std::vector<size_t>::const_iterator nodes_to_search_end2 =
+        nodes_to_search.end();
+    std::vector<size_t>::const_iterator nodes_to_search_end1 = std::lower_bound(
+        nodes_to_search_start1, nodes_to_search_end2, pruned_node->dfs_idx);
+    assert(*nodes_to_search_end1 >= pruned_sample.sample_name->dfs_idx);
+    std::vector<size_t>::const_iterator nodes_to_search_start2 =
+        std::upper_bound(nodes_to_search_end1, nodes_to_search_end2,
+                         pruned_node->dfs_end_idx);
+
+    const auto &sample_mutations = pruned_sample.sample_mutations;
+    int i = -1;
+    int j = 0;
+    const auto last_pos = sample_mutations.back().position - min_range;
+    int last_i = sample_mutations.size() - branch_len;
+    while (last_i > 0 && sample_mutations[last_i].position > last_pos) {
+        last_i--;
+    }
+
+    tbb::parallel_pipeline(
+        nthreads + 1,
+        tbb::make_filter<void, std::pair<int, int>>(
+            tbb::filter::serial_in_order,
+            search_position{sample_mutations, i, j, branch_len, min_range,
+                            max_range, last_i}) &
+            tbb::make_filter<std::pair<int, int>, void>(
+                tbb::filter::parallel,
+                check_breakpoint{out_ifc, sample_mutations,
+                                 nodes_to_search_start1, nodes_to_search_end1,
+                                 nodes_to_search_start2, nodes_to_search_end2,
+                                 node_size, pasimony_threshold,
+                                 dfs_ordered_nodes, T, valid_pairs})
+
+    );
+
+    
 }

--- a/src/ripples/ripples_fast/ripples.hpp
+++ b/src/ripples/ripples_fast/ripples.hpp
@@ -1,0 +1,113 @@
+#include <boost/program_options.hpp>
+#include <src/mutation_annotated_tree.hpp>
+#include <signal.h>
+
+namespace po = boost::program_options;
+
+namespace MAT = Mutation_Annotated_Tree;
+struct Ripples_Mapper_Mut {
+    static const unsigned short NULL_MUT_IDX = -1;
+    int position;
+    unsigned short mut_idx;
+    char curr_mut;
+    char dest_mut;
+    inline bool valid() const { return curr_mut != dest_mut; }
+    Ripples_Mapper_Mut()
+        : position(INT_MAX), mut_idx(NULL_MUT_IDX), curr_mut(0), dest_mut(0) {}
+    Ripples_Mapper_Mut(const MAT::Mutation &mut, size_t idx)
+        : position(mut.position), mut_idx(idx), curr_mut(mut.ref_nuc),
+          dest_mut(mut.mut_nuc) {
+    }
+    Ripples_Mapper_Mut(const MAT::Mutation &mut)
+        : position(mut.position), mut_idx(NULL_MUT_IDX), curr_mut(mut.mut_nuc),
+          dest_mut(mut.ref_nuc) {
+        //assert(mut.par_nuc == mut.ref_nuc);
+    }
+    Ripples_Mapper_Mut(const Ripples_Mapper_Mut &mut, char new_mut)
+        : position(mut.position), mut_idx(mut.mut_idx), curr_mut(new_mut),
+          dest_mut(mut.dest_mut) {}
+};
+class Mut_Count_t {
+    unsigned short internal;
+
+  public:
+    Mut_Count_t() {}
+    void set(unsigned short count_before_exclusive, bool is_self) {
+        internal = (is_self << 15) | count_before_exclusive;
+    }
+    unsigned short count_before_exclusive() const { return internal & 0x7fff; }
+    unsigned short is_self_counted() const { return (internal >> 15); }
+    unsigned short count_before_inclusive() const {
+        return count_before_exclusive() + is_self_counted();
+    }
+};
+typedef std::vector<Mut_Count_t> Mut_Count_Out_t;
+typedef std::vector<std::vector<Ripples_Mapper_Mut>> Mut_Out_t;
+
+struct Ripples_Mapper_Output_Interface {
+    Mut_Count_Out_t mut_count_out;
+    Mut_Out_t mut_out;
+    std::vector<char> is_sibling;
+};
+
+struct Pruned_Sample {
+    std::string sample_name;
+    std::vector<MAT::Mutation> sample_mutations;
+    std::unordered_set<uint32_t> positions;
+
+    // Assumes mutations are added in reverse chrono order
+    void add_mutation(MAT::Mutation mut);
+
+    Pruned_Sample(std::string name);
+};
+
+struct Recomb_Node {
+    std::string name;
+    int node_parsimony;
+    int parsimony;
+    char is_sibling;
+    Recomb_Node() {
+        name = "";
+        node_parsimony = -1;
+        parsimony = -1;
+        is_sibling = false;
+    }
+    Recomb_Node(std::string n, int np, int p, char s)
+        : name(n), node_parsimony(np), parsimony(p), is_sibling(s) {}
+    inline bool operator<(const Recomb_Node &n) const {
+        return (
+            ((*this).parsimony < n.parsimony) ||
+            (((*this).name < n.name) && ((*this).parsimony == n.parsimony)));
+    }
+};
+
+struct Recomb_Interval {
+    Recomb_Node d; // donor
+    Recomb_Node a; // acceptor
+    int start_range_low;
+    int start_range_high;
+    int end_range_low;
+    int end_range_high;
+    Recomb_Interval(Recomb_Node donor, Recomb_Node acceptor, int sl, int sh,
+                    int el, int eh)
+        : d(donor), a(acceptor), start_range_low(sl), start_range_high(sh),
+          end_range_low(el), end_range_high(eh) {}
+    bool
+    operator<(const Recomb_Interval &other) const { // compare second interval
+        return end_range_low < other.end_range_low;
+    }
+};
+
+struct Comp_First_Interval {
+    inline bool operator()(const Recomb_Interval &one,
+                           const Recomb_Interval &other) {
+        return one.start_range_low < other.start_range_low;
+    }
+};
+std::vector<Recomb_Interval>
+combine_intervals(std::vector<Recomb_Interval> pair_list);
+po::variables_map check_options(int argc, char **argv);
+void ripples_mapper(const Pruned_Sample &sample,
+                    Ripples_Mapper_Output_Interface &out,
+                    const std::vector<MAT::Node *> &dfs_ordered_nodes,
+                    const MAT::Node *root);

--- a/src/ripples/ripples_fast/ripples.hpp
+++ b/src/ripples/ripples_fast/ripples.hpp
@@ -47,7 +47,7 @@ typedef std::vector<std::vector<Ripples_Mapper_Mut>> Mut_Out_t;
 
 struct Ripples_Mapper_Output_Interface {
     Mut_Count_Out_t mut_count_out;
-    Mut_Out_t mut_out;
+    //Mut_Out_t mut_out;
     std::vector<char> is_sibling;
 };
 
@@ -110,11 +110,12 @@ combine_intervals(std::vector<Recomb_Interval> pair_list);
 po::variables_map check_options(int argc, char **argv);
 void ripples_mapper(const Pruned_Sample &sample,
                     Ripples_Mapper_Output_Interface &out,
-                    const std::vector<MAT::Node *> &dfs_ordered_nodes,
+                    size_t node_size,
+                    std::vector<int> idx_map,
                     const MAT::Node *root);
 void ripplrs_merger(const Pruned_Sample &pruned_sample,
-                    const std::vector<size_t> &nodes_to_search,
-                    std::vector<MAT::Node *> &dfs_ordered_nodes,
+                    const std::vector<int> & idx_map,
+                    const std::vector<MAT::Node *> &nodes_to_search,
                     size_t node_size, int pasimony_threshold,
                     const MAT::Tree &T,
                     tbb::concurrent_vector<Recomb_Interval> &valid_pairs,

--- a/src/ripples/ripples_fast/ripples.hpp
+++ b/src/ripples/ripples_fast/ripples.hpp
@@ -1,6 +1,7 @@
 #include <boost/program_options.hpp>
 #include <src/mutation_annotated_tree.hpp>
 #include <signal.h>
+#include <iostream>
 
 namespace po = boost::program_options;
 

--- a/src/ripples/ripples_fast/ripples.hpp
+++ b/src/ripples/ripples_fast/ripples.hpp
@@ -51,33 +51,33 @@ struct Ripples_Mapper_Output_Interface {
 };
 
 struct Pruned_Sample {
-    std::string sample_name;
+    MAT::Node* sample_name;
     std::vector<MAT::Mutation> sample_mutations;
     std::unordered_set<uint32_t> positions;
 
     // Assumes mutations are added in reverse chrono order
     void add_mutation(MAT::Mutation mut);
+    Pruned_Sample(){}
 
-    Pruned_Sample(std::string name);
+    Pruned_Sample(MAT::Node* name);
 };
 
 struct Recomb_Node {
-    std::string name;
+    const MAT::Node* node;
     int node_parsimony;
     int parsimony;
-    char is_sibling;
+    bool is_sibling;
     Recomb_Node() {
-        name = "";
         node_parsimony = -1;
         parsimony = -1;
         is_sibling = false;
     }
-    Recomb_Node(std::string n, int np, int p, char s)
-        : name(n), node_parsimony(np), parsimony(p), is_sibling(s) {}
+    Recomb_Node(const MAT::Node* node, int np, int p, char s)
+        : node(node), node_parsimony(np), parsimony(p), is_sibling(s) {}
     inline bool operator<(const Recomb_Node &n) const {
         return (
             ((*this).parsimony < n.parsimony) ||
-            (((*this).name < n.name) && ((*this).parsimony == n.parsimony)));
+            ((this->node->identifier < n.node->identifier) && ((*this).parsimony == n.parsimony)));
     }
 };
 
@@ -111,3 +111,12 @@ void ripples_mapper(const Pruned_Sample &sample,
                     Ripples_Mapper_Output_Interface &out,
                     const std::vector<MAT::Node *> &dfs_ordered_nodes,
                     const MAT::Node *root);
+void ripplrs_merger(const Pruned_Sample &pruned_sample,
+                    const std::vector<size_t> &nodes_to_search,
+                    std::vector<MAT::Node *> &dfs_ordered_nodes,
+                    size_t node_size, int pasimony_threshold,
+                    const MAT::Tree &T,
+                    tbb::concurrent_vector<Recomb_Interval> &valid_pairs,
+                    const Ripples_Mapper_Output_Interface &out_ifc,
+                    int nthreads, int branch_len, int min_range,
+                    int max_range) ;

--- a/src/ripples/ripples_fast/ripples_mapper.cpp
+++ b/src/ripples/ripples_fast/ripples_mapper.cpp
@@ -70,7 +70,6 @@ struct Mapper_Op : public tbb::task {
         auto this_idx = node->dfs_idx;
         auto &this_mut_out = cfg.get_mut(this_idx);
         bool has_unique=false;
-        bool have_not_shared=false;
         bool is_sibling=false;
         if (node->identifier=="node_7194")
         {

--- a/src/ripples/ripples_fast/ripples_mapper.cpp
+++ b/src/ripples/ripples_fast/ripples_mapper.cpp
@@ -72,7 +72,7 @@ struct Mapper_Op : public tbb::task {
         bool has_unique=false;
         bool have_not_shared=false;
         bool is_sibling=false;
-        if (node->identifier=="node_100005")
+        if (node->identifier=="node_7194")
         {
             //raise(SIGTRAP);
         }
@@ -97,7 +97,7 @@ struct Mapper_Op : public tbb::task {
                     if(!mut_for_descendant.valid()){
                         has_common=true;
                     }
-                    if((!iter->valid())&&mut_for_descendant.valid()){
+                    if(mut_for_descendant.valid()){
                         has_unique=true;
                     }
                     if (have_to_be_valid) {
@@ -108,6 +108,8 @@ struct Mapper_Op : public tbb::task {
                     if (this_mut.mut_nuc != iter->dest_mut) {
                         this_mut_out.emplace_back(*iter, this_mut.mut_nuc);
                         mut_accumulated++;
+                    }else{
+                        has_common=true;
                     }
                 }
                 iter++;
@@ -116,6 +118,8 @@ struct Mapper_Op : public tbb::task {
                 if (this_mut.mut_nuc != this_mut.ref_nuc) {
                     this_mut_out.emplace_back(this_mut);
                     has_unique=true;
+                }else{
+                    has_common=true;
                 }
             }
         }
@@ -125,10 +129,10 @@ struct Mapper_Op : public tbb::task {
         }
         //Artifically increase mutation by one for spliting?
         is_sibling=((has_unique && !node->children.empty() && (has_common)) || \
-                                  (node->children.empty() && (has_common)) || (!has_unique && node->children.empty() ));
+                                  (node->children.empty() && (has_common)) || (!has_unique && !node->children.empty() ));
         cfg.get_final_mut_count_ref(this_idx).set(mut_accumulated,false);
         }
-        cfg.set_sibling(this_idx,has_unique);
+        cfg.set_sibling(this_idx,is_sibling);
         auto cont=new (allocate_continuation()) tbb::empty_task;
         cont->set_ref_count(node->children.size());
         for(const auto child:node->children){

--- a/src/ripples/ripples_fast/ripples_mapper.cpp
+++ b/src/ripples/ripples_fast/ripples_mapper.cpp
@@ -1,0 +1,150 @@
+#include "ripples.hpp"
+void prep_output(const Pruned_Sample &sample,
+                 Ripples_Mapper_Output_Interface &out, size_t node_size) {
+    const auto &init_mut = sample.sample_mutations;
+    out.mut_count_out.resize(node_size * (init_mut.size() + 1));
+    out.mut_out.resize(node_size);
+    out.is_sibling.resize(node_size);
+    std::vector<Ripples_Mapper_Mut> &init = out.mut_out[0];
+    init.reserve(init_mut.size() + 1);
+    for (size_t mut_idx = 0; mut_idx < init_mut.size(); mut_idx++) {
+        init.emplace_back(init_mut[mut_idx], mut_idx);
+        out.mut_count_out[mut_idx * node_size].set(mut_idx, true);
+    }
+    out.mut_count_out[(init_mut.size()) * node_size].set(init_mut.size(), true);
+    init.emplace_back();
+}
+struct Mapper_Op_Common{
+    Ripples_Mapper_Output_Interface &out;
+    const size_t stride;
+    const size_t mut_count;
+    Mut_Count_t& get_mut_count_ref(size_t node_idx,unsigned short mut_idx){
+        return out.mut_count_out[mut_idx*stride+node_idx];
+    }
+    Mut_Count_t& get_final_mut_count_ref(size_t node_idx){
+        return out.mut_count_out[mut_count*stride+node_idx];
+    }
+    std::vector<Ripples_Mapper_Mut>& get_mut(size_t node_idx){
+        return out.mut_out[node_idx];
+    }
+    void set_sibling(size_t node_idx,bool is_sibling){
+        out.is_sibling[node_idx]=is_sibling;
+    }
+};
+std::pair<const MAT::Node*,MAT::Mutation> get_parent_mut(const MAT::Node* node,int pos){
+    node=node->parent;
+    while (node!=nullptr)
+    {
+        for(auto mut:node->mutations){
+            if(mut.position==pos){
+                return std::make_pair(node,mut);
+            }
+        }
+        node=node->parent;
+    }
+    return std::make_pair(nullptr,MAT::Mutation());
+}
+struct Mapper_Op : public tbb::task {
+    const std::vector<Ripples_Mapper_Mut> &parent_muts;
+    Mapper_Op_Common cfg;
+    const MAT::Node *node;
+    Mapper_Op(const std::vector<Ripples_Mapper_Mut> &parent_muts,
+              Mapper_Op_Common cfg,
+              const MAT::Node *node)
+        : parent_muts(parent_muts), cfg(cfg), node(node) {}
+    void only_from_parent(const Ripples_Mapper_Mut& mut,size_t this_idx,unsigned short& mut_accumulated,std::vector<Ripples_Mapper_Mut>& this_mut_out){
+        auto is_valid = mut.valid();
+                if (mut.mut_idx != mut.NULL_MUT_IDX) {
+                    cfg.get_mut_count_ref(this_idx,mut.mut_idx).set(
+                        mut_accumulated, is_valid);
+                }
+                if (is_valid) {
+                    mut_accumulated++;
+                }
+                this_mut_out.push_back(mut);
+    }
+    tbb::task *execute() override {
+        auto iter = parent_muts.begin();
+        auto end = parent_muts.end();
+        unsigned short mut_accumulated = 0;
+        auto this_idx = node->dfs_idx;
+        auto &this_mut_out = cfg.get_mut(this_idx);
+        bool is_sibling=false;
+        bool have_not_shared=false;
+        if (node->identifier=="node_100005")
+        {
+            //raise(SIGTRAP);
+        }
+        bool has_common=false;
+        if(this_idx!=0){
+        for (const auto &this_mut : node->mutations) {
+            while (iter->position < this_mut.position) {
+                only_from_parent(*iter,this_idx,mut_accumulated,this_mut_out);
+                iter++;
+            }
+            if (iter->position == this_mut.position) {
+                if (iter->mut_idx != iter->NULL_MUT_IDX) {
+                    // Position being counted
+                    // Need descendant to know no matter whether it is valid
+                    this_mut_out.emplace_back(*iter, this_mut.mut_nuc);
+                    auto &mut_for_descendant = this_mut_out.back();
+                    // May be splited
+                    bool have_to_be_valid =
+                        mut_for_descendant.valid() && iter->valid();
+                        cfg.get_mut_count_ref(this_idx,iter->mut_idx).set(
+                        mut_accumulated, have_to_be_valid);
+                    if(!mut_for_descendant.valid()){
+                        has_common=true;
+                    }
+                    if((!iter->valid())&&mut_for_descendant.valid()){
+                        is_sibling=true;
+                    }
+                    if (have_to_be_valid) {
+                        mut_accumulated++;
+                    }
+                } else {
+                    assert(iter->valid());
+                    if (this_mut.mut_nuc != iter->dest_mut) {
+                        this_mut_out.emplace_back(*iter, this_mut.mut_nuc);
+                        mut_accumulated++;
+                    }
+                }
+                iter++;
+            } else {
+                //Only at this node, back mutations for descendant, but maybe split
+                if (this_mut.mut_nuc != this_mut.ref_nuc) {
+                    this_mut_out.emplace_back(this_mut);
+                    is_sibling=true;
+                }
+            }
+        }
+        while (iter < end) {
+                only_from_parent(*iter,this_idx,mut_accumulated,this_mut_out);
+                iter++;
+        }
+        //Artifically increase mutation by one for spliting?
+        if(node->children.empty()||!has_common){
+            is_sibling=true;
+        }
+        cfg.get_final_mut_count_ref(this_idx).set(mut_accumulated,false);
+        }
+        cfg.set_sibling(this_idx,is_sibling);
+        auto cont=new (allocate_continuation()) tbb::empty_task;
+        cont->set_ref_count(node->children.size());
+        for(const auto child:node->children){
+            cont->spawn(* new(cont->allocate_child()) Mapper_Op(this_mut_out,cfg,child));
+        }
+        return node->children.empty()?cont:nullptr;
+    }
+};
+void ripples_mapper(const Pruned_Sample &sample,
+                    Ripples_Mapper_Output_Interface &out,
+                    const std::vector<MAT::Node *> &dfs_ordered_nodes,
+                    const MAT::Node *root) {
+    auto temp=get_parent_mut(root,0);
+    auto node_size = dfs_ordered_nodes.size();
+    auto mut_size = sample.sample_mutations.size();
+    prep_output(sample, out, node_size);
+    Mapper_Op_Common cfg{out,node_size,mut_size};
+    tbb::task::spawn_root_and_wait(*new( tbb::task::allocate_root())Mapper_Op(out.mut_out[0],cfg,root) );
+}

--- a/src/ripples/ripples_fast/ripples_mapper.cpp
+++ b/src/ripples/ripples_fast/ripples_mapper.cpp
@@ -1,11 +1,15 @@
 #include "ripples.hpp"
-void prep_output(const Pruned_Sample &sample,
+struct Mapper_Cont:public tbb::task{
+    std::vector<Ripples_Mapper_Mut> muts;
+    tbb::task* execute() override{
+        return nullptr;
+    }
+};
+void prep_output(const Pruned_Sample &sample,std::vector<Ripples_Mapper_Mut> &init ,
                  Ripples_Mapper_Output_Interface &out, size_t node_size) {
     const auto &init_mut = sample.sample_mutations;
     out.mut_count_out.resize(node_size * (init_mut.size() + 1));
-    out.mut_out.resize(node_size);
     out.is_sibling.resize(node_size);
-    std::vector<Ripples_Mapper_Mut> &init = out.mut_out[0];
     init.reserve(init_mut.size() + 1);
     for (size_t mut_idx = 0; mut_idx < init_mut.size(); mut_idx++) {
         init.emplace_back(init_mut[mut_idx], mut_idx);
@@ -18,14 +22,12 @@ struct Mapper_Op_Common{
     Ripples_Mapper_Output_Interface &out;
     const size_t stride;
     const size_t mut_count;
+    const std::vector<int>& idx_map;
     Mut_Count_t& get_mut_count_ref(size_t node_idx,unsigned short mut_idx){
         return out.mut_count_out[mut_idx*stride+node_idx];
     }
     Mut_Count_t& get_final_mut_count_ref(size_t node_idx){
         return out.mut_count_out[mut_count*stride+node_idx];
-    }
-    std::vector<Ripples_Mapper_Mut>& get_mut(size_t node_idx){
-        return out.mut_out[node_idx];
     }
     void set_sibling(size_t node_idx,bool is_sibling){
         out.is_sibling[node_idx]=is_sibling;
@@ -46,10 +48,10 @@ std::pair<const MAT::Node*,MAT::Mutation> get_parent_mut(const MAT::Node* node,i
 }
 struct Mapper_Op : public tbb::task {
     const std::vector<Ripples_Mapper_Mut> &parent_muts;
-    Mapper_Op_Common cfg;
+    Mapper_Op_Common& cfg;
     const MAT::Node *node;
     Mapper_Op(const std::vector<Ripples_Mapper_Mut> &parent_muts,
-              Mapper_Op_Common cfg,
+              Mapper_Op_Common& cfg,
               const MAT::Node *node)
         : parent_muts(parent_muts), cfg(cfg), node(node) {}
     void only_from_parent(const Ripples_Mapper_Mut& mut,size_t this_idx,unsigned short& mut_accumulated,std::vector<Ripples_Mapper_Mut>& this_mut_out){
@@ -63,19 +65,13 @@ struct Mapper_Op : public tbb::task {
                 }
                 this_mut_out.push_back(mut);
     }
-    tbb::task *execute() override {
+    void set_mut_count(int this_idx,std::vector<Ripples_Mapper_Mut>& this_mut_out){
         auto iter = parent_muts.begin();
         auto end = parent_muts.end();
         unsigned short mut_accumulated = 0;
-        auto this_idx = node->dfs_idx;
-        auto &this_mut_out = cfg.get_mut(this_idx);
         bool has_unique=false;
-        bool is_sibling=false;
-        if (node->identifier=="node_7194")
-        {
-            //raise(SIGTRAP);
-        }
         bool has_common=false;
+        bool is_sibling=false;
         if(this_idx!=0){
         for (const auto &this_mut : node->mutations) {
             while (iter->position < this_mut.position) {
@@ -126,28 +122,85 @@ struct Mapper_Op : public tbb::task {
                 only_from_parent(*iter,this_idx,mut_accumulated,this_mut_out);
                 iter++;
         }
-        //Artifically increase mutation by one for spliting?
+                //Artifically increase mutation by one for spliting?
         is_sibling=((has_unique && !node->children.empty() && (has_common)) || \
                                   (node->children.empty() && (has_common)) || (!has_unique && !node->children.empty() ));
         cfg.get_final_mut_count_ref(this_idx).set(mut_accumulated,false);
         }
         cfg.set_sibling(this_idx,is_sibling);
-        auto cont=new (allocate_continuation()) tbb::empty_task;
+    }
+    void merge_mutation_only(std::vector<Ripples_Mapper_Mut>& this_mut_out){
+         auto iter = parent_muts.begin();
+        auto end = parent_muts.end();
+        for (const auto &this_mut : node->mutations) {
+            while (iter->position < this_mut.position) {
+                this_mut_out.push_back((*iter));
+                iter++;
+            }
+            if (iter->position == this_mut.position) {
+                if (iter->mut_idx != iter->NULL_MUT_IDX) {
+                    this_mut_out.emplace_back(*iter, this_mut.mut_nuc);
+                } else {
+                    assert(iter->valid());
+                    if (this_mut.mut_nuc != iter->dest_mut) {
+                        this_mut_out.emplace_back(*iter, this_mut.mut_nuc);
+                    }
+                }
+                iter++;
+            } else {
+                //Only at this node, back mutations for descendant, but maybe split
+                if (this_mut.mut_nuc != this_mut.ref_nuc) {
+                    this_mut_out.emplace_back(this_mut);
+                }
+            }
+        }
+        while (iter < end) {
+                this_mut_out.push_back((*iter));
+                iter++;
+        }
+    }
+    tbb::task *execute() override {
+        auto this_idx = cfg.idx_map[node->dfs_idx];
+        auto cont=new (allocate_continuation()) Mapper_Cont;
+        auto &this_mut_out = cont->muts;
+
+        if (node->identifier=="node_7194")
+        {
+            //raise(SIGTRAP);
+        }
+        if (this_idx>=0)
+        {
+            set_mut_count(this_idx,this_mut_out);
+        }else{
+            merge_mutation_only(this_mut_out);
+        }
+
         cont->set_ref_count(node->children.size());
-        for(const auto child:node->children){
-            cont->spawn(* new(cont->allocate_child()) Mapper_Op(this_mut_out,cfg,child));
+        if (this_idx == 0) {
+            for (const auto child : node->children) {
+                cont->spawn(*new (cont->allocate_child())
+                                Mapper_Op(parent_muts, cfg, child));
+            }
+        } else {
+
+            for (const auto child : node->children) {
+                cont->spawn(*new (cont->allocate_child())
+                                Mapper_Op(this_mut_out, cfg, child));
+            }
         }
         return node->children.empty()?cont:nullptr;
     }
 };
 void ripples_mapper(const Pruned_Sample &sample,
                     Ripples_Mapper_Output_Interface &out,
-                    const std::vector<MAT::Node *> &dfs_ordered_nodes,
+                    size_t node_size,
+                    std::vector<int> idx_map,
                     const MAT::Node *root) {
     auto temp=get_parent_mut(root,0);
-    auto node_size = dfs_ordered_nodes.size();
     auto mut_size = sample.sample_mutations.size();
-    prep_output(sample, out, node_size);
-    Mapper_Op_Common cfg{out,node_size,mut_size};
-    tbb::task::spawn_root_and_wait(*new( tbb::task::allocate_root())Mapper_Op(out.mut_out[0],cfg,root) );
+    std::vector<Ripples_Mapper_Mut> root_muts;
+    prep_output(sample, root_muts,out, node_size);
+    Mapper_Op_Common cfg{out,node_size,mut_size,idx_map};
+    tbb::task::spawn_root_and_wait(
+        *new( tbb::task::allocate_root())Mapper_Op(root_muts,cfg,root) );
 }


### PR DESCRIPTION
It now takes 1 instead of 4 hours on the May 25 tree. It can still be faster, and more testing on other trees is needed.

Other than the is_sibling columns, the output match. I feel these columns are not set in the original ripples if the node is not optimal. (The only update to node_has_unique is at lines 165-195 in usher_mapper.cpp ) This version update it for all the node (correctly, because donor/acceptor parsimony score columns match, and usher_mapper.cpp:503 will artificially increase the parsimony score if it is placed as children).