### PR TITLE
Allow --clade-paths to work in conjunction with --clade-mutations and --clade-names

### DIFF
--- a/src/matUtils/annotate.hpp
+++ b/src/matUtils/annotate.hpp
@@ -3,5 +3,5 @@
 po::variables_map parse_annotate_command(po::parsed_options parsed);
 void annotate_main(po::parsed_options parsed);
 void assignLineages (MAT::Tree& T, const std::string& lineage_filename, bool clear_current = false);
-void assignLineages (MAT::Tree& T, const std::string& clade_filename, const std::string& clade_mutations_filename, float min_freq, float mask_freq, float set_overlap, float clip_sample_frequency, bool clear_current = false, const std::string& mutations_filename = "", const std::string& details_filename = "");
-void assignLineagesFromPaths (MAT::Tree& T, const std::string& clade_paths_filename, bool clear_current = false);
+void assignLineages (MAT::Tree& T, const std::string& clade_filename, const std::string& clade_mutations_filename, const std::string& clade_paths_filename, float min_freq, float mask_freq, float set_overlap, float clip_sample_frequency, bool clear_current = false, const std::string& mutations_filename = "", const std::string& details_filename = "");
+void assignLineagesFromPaths (MAT::Tree& T, const std::string& clade_paths_filename, std::unordered_set<std::string>& clades_already_assigned);

--- a/src/matUtils/summary.cpp
+++ b/src/matUtils/summary.cpp
@@ -251,25 +251,37 @@ void write_sample_clades_table (MAT::Tree* T, std::string sample_clades) {
     fprintf(stderr, "Writing clade associations for all samples to output %s\n", sample_clades.c_str());
     std::ofstream scfile;
     scfile.open(sample_clades);
-    scfile << "sample\tannotation_1\tannotation_2\n";
+    size_t num_annotations = T->get_num_annotations();
+    scfile << "sample";
+    for (size_t i = 1;  i <= num_annotations;  i++) {
+        scfile << "\tannotation_" << i;
+    }
+    scfile << "\n";
     for (auto n: T->get_leaves()) {
-        std::string ann_1 = "None";
-        std::string ann_2 = "None";
+        std::vector<std::string> annotations_found (num_annotations, "None");
         for (auto a: T->rsearch(n->identifier, false)) {
             std::vector<std::string> canns = a->clade_annotations;
-            for (size_t i = 0; i < canns.size(); i++) {
-                if ((i == 0) && (canns[i] != "") && (ann_1 == "None")) {
-                    ann_1 = canns[i];
+            for (size_t i = 0; i < num_annotations; i++) {
+                if (canns[i] != "" && annotations_found[i] == "None") {
+                    annotations_found[i] = canns[i];
                 }
-                if ((i == 1) && (canns[i] != "") && (ann_2 == "None")) {
-                    ann_2 = canns[i];
-                }
-                if ((ann_1 != "None") && (ann_2 != "None")) {
+            }
+            bool all_found = true;
+            for (size_t i = 0;  i < num_annotations;  i++) {
+                if (annotations_found[i] == "None") {
+                    all_found = false;
                     break;
                 }
             }
+            if (all_found) {
+                break;
+            }
         }
-        scfile << n->identifier << "\t" << ann_1 << "\t" << ann_2 << "\n";
+        scfile << n->identifier;
+        for (size_t i = 0;  i < num_annotations;  i++) {
+            scfile << "\t" << annotations_found[i];
+        }
+        scfile << "\n";
     }
     fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
     scfile.close();


### PR DESCRIPTION
Currently in `matUtils annotate`, `--clade-mutations` and `--clade-names` can be used simultaneously with `--clade-mutations` taking precedence, but `--clade-paths` is mutually exclusive with all other `--clade-*` options.  This change allows all three of `--clade-paths`, `--clade-mutations` and `--clade-names` to be used simultaneously, with `--clade-paths` taking highest precedence.  (The options can still be used separately.)

When all three options are used together, first we try the paths file; any clade annotated by path will be ignored if we encounter it again in the mutations or names files.  Then we try the mutations file and then names as fallbacks for paths that can't be found because the order of mutations has changed.  This combines the speed of the paths method with the robustness of the mutations/names method.

I have tested this by running a local test case with different combinations of options, and have been using all three options together in the big tree daily build for over a week.  Annotating nodes on the big tree (approaching 10M sequences) now takes 5-30 minutes (depending on how many paths change, usually 5 minutes) instead of 6-7 hours.

Also, `matUtils summary -C sample-clades -i ...` was hardcoded to write out two columns of annotations (assuming Nextstrain clade and Pango lineage) regardless of how many annotations are present; this PR also includes an update so that it prints out however many annotations are present.