### PR TITLE
Add --within-distance to matUtils extract (output all samples within k mutations of target samples)

### DIFF
--- a/src/matUtils/extract.cpp
+++ b/src/matUtils/extract.cpp
@@ -103,6 +103,10 @@ po::variables_map parse_extract_command(po::parsed_options parsed) {
      "Write a tsv file of the closest relative(s) (in mutations) of each selected sample to the indicated file. All equidistant closest samples are included unless --break-ties is set.")
     ("break-ties,q", po::bool_switch(),
      "Only output one closest relative per sample (used only with --closest-relatives). If multiple closest relatives are equidistant, the lexicographically smallest sample ID is chosen.")
+    ("within-distance", po::value<std::string>()->default_value(""),
+    "Write a tsv file of the relatives within --distance-thresold mutations of each selected sample to the indicated file.")
+    ("distance-threshold", po::value<size_t>()->default_value(0),
+     "Specifies the distance threshold used in --within-distance.")
     ("dump-metadata,Q", po::value<std::string>()->default_value(""),
      "Set to write all final stored metadata to a tsv.")
     ("whitelist,L", po::value<std::string>()->default_value(""),
@@ -167,6 +171,7 @@ void extract_main (po::parsed_options parsed) {
     float x_scale = vm["x-scale"].as<float>();
     bool break_ties = vm["break-ties"].as<bool>();
     bool include_nt = vm["include-nt"].as<bool>();
+    size_t distance_threshold = vm["distance-threshold"].as<size_t>();
 
     boost::filesystem::path path(dir_prefix);
     if (!boost::filesystem::exists(path)) {
@@ -181,6 +186,7 @@ void extract_main (po::parsed_options parsed) {
     std::string clade_path_filename = dir_prefix + vm["clade-paths"].as<std::string>();
     std::string all_path_filename = dir_prefix + vm["all-paths"].as<std::string>();
     std::string closest_relatives_filename = dir_prefix + vm["closest-relatives"].as<std::string>();
+    std::string within_dist_filename = dir_prefix + vm["within-distance"].as<std::string>();
     std::string tree_filename = dir_prefix + vm["write-tree"].as<std::string>();
     std::string vcf_filename = dir_prefix + vm["write-vcf"].as<std::string>();
     std::string output_mat_filename = dir_prefix + vm["write-mat"].as<std::string>();
@@ -208,7 +214,7 @@ void extract_main (po::parsed_options parsed) {
     return f != dir_prefix;
 }) &&
 usher_single_subtree_size == 0 && usher_minimum_subtrees_size == 0) {
-        if (nearest_k_batch_file == "" && closest_relatives_filename == dir_prefix) {
+        if (nearest_k_batch_file == "" && closest_relatives_filename == dir_prefix && within_dist_filename == dir_prefix) {
             fprintf(stderr, "ERROR: No output files requested!\n");
             exit(1);
         }
@@ -696,7 +702,7 @@ usher_single_subtree_size == 0 && usher_minimum_subtrees_size == 0) {
         std::vector<std::string> closest_relatives;
 
         for (std::string sample : samples) {
-            std::pair<std::vector<std::string>, size_t> closest_relatives_pair = get_closest_samples(&T, sample);
+            std::pair<std::vector<std::string>, size_t> closest_relatives_pair = get_closest_samples(&T, sample, false, 0);
             std::vector<std::string> closest_relatives = closest_relatives_pair.first;
             size_t dist = closest_relatives_pair.second;
             if (closest_relatives.size() > 0) {
@@ -723,6 +729,23 @@ usher_single_subtree_size == 0 && usher_minimum_subtrees_size == 0) {
             }
         }
         fprintf(stderr, "TSV of closest relative written to %s in %ld msec.\n\n", closest_relatives_filename.c_str(), timer.Stop());
+    }
+    if (within_dist_filename != dir_prefix) {
+        fprintf(stderr, "Computing per-sample relatives within %ld mutations...", distance_threshold);
+        std::ofstream out(within_dist_filename);
+
+        for (std::string sample : samples) {
+            std::pair<std::vector<std::string>, size_t> relatives_pair = get_closest_samples(&T, sample, true, distance_threshold);
+            std::vector<std::string> relatives = relatives_pair.first;
+            std::string s = "";
+            s += sample + '\t';
+            for (std::string relative : relatives) {
+                s += relative + ',';
+            }
+            s = s.substr(0, s.size() - 1);
+            out << s << "\n";
+        }
+        fprintf(stderr, "TSV of relatives within threshold written to %s in %ld msec.\n\n", within_dist_filename.c_str(), timer.Stop());
     }
     //if json output AND sample context is requested, add an additional metadata column which simply indicates the focal sample versus context
     if ((json_filename != "") && (nearest_k != "")) {

--- a/src/matUtils/select.cpp
+++ b/src/matUtils/select.cpp
@@ -444,14 +444,18 @@ std::vector<std::string> get_mrca_samples(MAT::Tree* T, std::vector<std::string>
 }
 
 void closest_samples_dfs(MAT::Node *node, MAT::Node *target, size_t path_length, size_t max_path_length, std::vector<std::pair<MAT::Node *, size_t>> &leaves) {
+
+    
+
     if (path_length > max_path_length) {
+        
         return;
     }
     for (auto child : node->children) {
         if (child->is_leaf()) {
-            leaves.push_back(std::make_pair(child, path_length + child->branch_length));
+            leaves.push_back(std::make_pair(child, path_length + child->mutations.size()));
         } else {
-            closest_samples_dfs(child, target, path_length + child->branch_length, max_path_length, leaves);
+            closest_samples_dfs(child, target, path_length + child->mutations.size(), max_path_length, leaves);
         }
     }
 }
@@ -461,6 +465,8 @@ std::pair<std::vector<std::string>, size_t> get_closest_samples(MAT::Tree* T, st
     std::pair<std::vector<std::string>, size_t> closest_samples;
 
     MAT::Node *target = T->get_node(nid);
+    MAT::Node *target_parent = target->parent;
+    
     MAT::Node *curr_target = T->get_node(nid);
 
     if (!target) {
@@ -472,57 +478,76 @@ std::pair<std::vector<std::string>, size_t> get_closest_samples(MAT::Tree* T, st
     size_t min_dist = std::numeric_limits<size_t>::max();
     size_t dist_to_orig_parent = 0; // cumulative distance to the parent of the initial target
 
+    
     bool go_up = true;
     while (go_up && parent) {
-
-        size_t parent_branch_length = parent->branch_length + dist_to_orig_parent;
+        size_t parent_branch_length = parent->mutations.size() + dist_to_orig_parent;
+        
         // make a vector of siblings of the current target.
         // for siblings that are internal nodes, add leaves in the descendant subtree
         // as pseudo-children if they are close enough
         std::vector<std::pair<MAT::Node *, size_t>> children_and_distances;
-
+        
         size_t min_of_sibling_leaves = std::numeric_limits<size_t>::max();
+        //collect leaves
         for (auto child : parent->children) {
+            
             if (child->is_leaf()) {
+                
                 if (child->identifier == curr_target->identifier) {
+                    
                     continue; // skip the target node
                 }
-                size_t child_branch_length = child->branch_length;
+                size_t child_branch_length = child->mutations.size();
+                
                 if (child_branch_length < min_of_sibling_leaves) {
+                    
                     min_of_sibling_leaves = child_branch_length;
                 }
             }
         }
+        
         for (auto child : parent->children) {
+            
             if (child->identifier == curr_target->identifier) {
+                
                 continue; // skip the target node
+            }
+            if (child->identifier == target_parent->identifier) {
+                continue; // don't go back down path
             }
 
             if (!child->is_leaf()) {
+                
                 // for internal nodes, descend the tree, adding leaves as they are
                 // encountered, restricting path lengths to less than the minimum of
                 // the sibling leaves at the current level
-                size_t dist_so_far = child->branch_length;
-                closest_samples_dfs(child, target, dist_so_far, min_of_sibling_leaves, children_and_distances);
+                size_t dist_so_far = child->mutations.size() + dist_to_orig_parent;
+                
+                closest_samples_dfs(child, target, dist_so_far, min_of_sibling_leaves + dist_so_far, children_and_distances);
 
             } else { // leaf node
-                children_and_distances.push_back(std::make_pair(child, dist_to_orig_parent + child->branch_length));
+                
+                children_and_distances.push_back(std::make_pair(child, dist_to_orig_parent + child->mutations.size()));
             }
         }
 
         for (std::pair child_and_dist : children_and_distances) {
+            
             // for the siblings of the target node, if any branch lengths
             // are shorter than the path up a level, we can stop
             MAT::Node *child = child_and_dist.first;
-            size_t child_branch_length = child_and_dist.second + dist_to_orig_parent;
+            size_t child_branch_length = child_and_dist.second;
             if (child_branch_length < parent_branch_length) {
+                
                 go_up = false;
             }
             if (child_branch_length < min_dist) {
+                
                 min_dist = child_branch_length;
                 closest_samples.first.clear();
                 closest_samples.first.push_back(child->identifier);
-                closest_samples.second = min_dist + target->branch_length;
+                closest_samples.second = min_dist + target->mutations.size();
 
             } else if (child_branch_length == min_dist) {
                 closest_samples.first.push_back(child->identifier);
@@ -530,7 +555,8 @@ std::pair<std::vector<std::string>, size_t> get_closest_samples(MAT::Tree* T, st
         }
         curr_target = parent;
         parent = curr_target->parent;
-        dist_to_orig_parent += parent_branch_length;
+        dist_to_orig_parent = parent_branch_length;
+        
     }
     return closest_samples;
 }

--- a/src/matUtils/select.hpp
+++ b/src/matUtils/select.hpp
@@ -14,4 +14,4 @@ std::unordered_map<std::string,std::unordered_map<std::string,std::string>> read
 std::vector<std::string> get_sample_match(MAT::Tree* T, std::vector<std::string> samples_to_check, std::string substring);
 std::vector<std::string> fill_random_samples(MAT::Tree* T, std::vector<std::string> current_samples, size_t target_size, bool lca_limit = false);
 std::vector<std::string> get_mrca_samples(MAT::Tree* T, std::vector<std::string> current_samples);
-std::pair<std::vector<std::string>, size_t> get_closest_samples(MAT::Tree* T, std::string nid);
+std::pair<std::vector<std::string>, size_t> get_closest_samples(MAT::Tree* T, std::string nid, bool fixed_k, size_t k);


### PR DESCRIPTION
This adds two options to `matUtils extract`: `--within-distance [filename]` and `--distance-threshold [int]` which are used to write a TSV file listing all sample IDs within `distance-threshold` of the selected samples.

E.g. `matUtils extract --within-distance output.tsv --distance-threshold 4 -s input_samples.tsv -i tree.pb.gz`

The first column in the TSV output contains one sample from the input set per line, and the second column is a comma-separated list of all samples within the specified threshold of that line's sample.

This also fixes a small bug in the logic for `extract --closest-relatives`
