### PR TITLE
Make nodes with changed major allele set available to larch through the callback

### DIFF
--- a/src/matOptimize/Profitable_Moves_Enumerators/Bounded_Search.hpp
+++ b/src/matOptimize/Profitable_Moves_Enumerators/Bounded_Search.hpp
@@ -20,6 +20,7 @@ struct src_side_info {
     MAT::Node *LCA;
     MAT::Node *src;
     Mutation_Count_Change_Collection allele_count_change_from_src;
+    std::vector<Node_With_Major_Allele_Set_Change> node_with_major_allele_set_change;
 };
 struct ignore_ranger_nop {
     ignore_ranger_nop(const Mutation_Annotated_Tree::ignored_t& in) {}

--- a/src/matOptimize/Profitable_Moves_Enumerators/Profitable_Moves_Enumerators.hpp
+++ b/src/matOptimize/Profitable_Moves_Enumerators/Profitable_Moves_Enumerators.hpp
@@ -6,11 +6,6 @@
 #include <vector>
 #include <array>
 #include "../stack_allocator.hpp"
-struct Move_Found_Callback{
-    bool operator()(Profitable_Moves move,int best_score_change){
-        return move.score_change <= best_score_change;
-    }
-};
 typedef std::vector<std::array<std::vector<unsigned int>, 4>> mutated_node_dfs_idx_t;
 extern mutated_node_dfs_idx_t mutated_node_dfs_idx;
 namespace MAT = Mutation_Annotated_Tree;
@@ -152,6 +147,15 @@ struct Reachable {
     bool reachable_change;
     bool always_search;
 };
+struct Node_With_Major_Allele_Set_Change{
+    MAT::Node* node;
+    Mutation_Count_Change_Collection major_allele_set_change;
+};
+struct Move_Found_Callback{
+    bool operator()(Profitable_Moves move,int best_score_change,std::vector<Node_With_Major_Allele_Set_Change>& node_with_major_allele_set_change){
+        return move.score_change <= best_score_change;
+    }
+};
 void find_moves_bounded(MAT::Node* src,output_t& out,int search_radius,bool do_drift,Reachable,Move_Found_Callback& callback
 #ifdef CHECK_BOUND
                         ,counters& count
@@ -185,11 +189,12 @@ struct range_tree {
     }
 };
 bool output_result(MAT::Node *src, MAT::Node *dst, MAT::Node *LCA,
-                   int parsimony_score_change, output_t &output,int radius_left,Move_Found_Callback& callback);
+                   int parsimony_score_change, output_t &output,int radius_left,Move_Found_Callback& callback,std::vector<Node_With_Major_Allele_Set_Change>& major_alllele_count_changes_hist);
 extern std::vector<range_tree> addable_idxes;
 void check_parsimony_score_change_above_LCA(MAT::Node *start_node, int &parsimony_score_change,
         Mutation_Count_Change_Collection &parent_added,
-        Mutation_Count_Change_Collection &parent_of_parent_added);
+        Mutation_Count_Change_Collection &parent_of_parent_added,
+        std::vector<Node_With_Major_Allele_Set_Change>& major_alllele_count_changes_hist);
 bool dst_branch(const MAT::Node *LCA,
                 const range<Mutation_Count_Change> &mutations,
                 int &parsimony_score_change, MAT::Node *this_node,

--- a/src/matOptimize/Profitable_Moves_Enumerators/Profitable_Moves_Enumerators.hpp
+++ b/src/matOptimize/Profitable_Moves_Enumerators/Profitable_Moves_Enumerators.hpp
@@ -2,7 +2,9 @@
 #define PROFITABLE_MOVES_ENUMERATOR
 #include "../tree_rearrangement_internal.hpp"
 #include "src/matOptimize/mutation_annotated_tree.hpp"
+#include <csignal>
 #include <cstdint>
+#include <cstdio>
 #include <vector>
 #include <array>
 #include "../stack_allocator.hpp"

--- a/src/matOptimize/Profitable_Moves_Enumerators/check_move_profitable.cpp
+++ b/src/matOptimize/Profitable_Moves_Enumerators/check_move_profitable.cpp
@@ -19,8 +19,9 @@ static void check_LCA(MAT::Node* src, MAT::Node* dst,MAT::Node* LCA_to_check) {
 #endif
 
 bool output_result(MAT::Node *src, MAT::Node *dst, MAT::Node *LCA,
-                   int parsimony_score_change, output_t &output,int radius_left,Move_Found_Callback& callback) {
-    if (callback(Profitable_Moves{parsimony_score_change,src,dst,LCA,radius_left},output.score_change)) {
+                   int parsimony_score_change, output_t &output,int radius_left,Move_Found_Callback& callback,
+                    std::vector<Node_With_Major_Allele_Set_Change>& major_alllele_count_changes_hist) {
+    if (callback(Profitable_Moves{parsimony_score_change,src,dst,LCA,radius_left},output.score_change,major_alllele_count_changes_hist)) {
         if (parsimony_score_change < output.score_change) {
             output.score_change = parsimony_score_change;
             output.moves->clear();
@@ -108,13 +109,14 @@ int check_move_profitable_dst_not_LCA(
         get_LCA_mutation(LCA,src, root_mutations_altered, dst_added, parent_of_parent_added, parsimony_score_change);
     }
     dst_added.swap(parent_of_parent_added);
-    check_parsimony_score_change_above_LCA(LCA->parent, parsimony_score_change, dst_added, parent_of_parent_added);
+    std::vector<Node_With_Major_Allele_Set_Change> major_alllele_count_changes_hist;
+    check_parsimony_score_change_above_LCA(LCA->parent, parsimony_score_change, dst_added, parent_of_parent_added,major_alllele_count_changes_hist);
 #ifdef DEBUG_PARSIMONY_SCORE_CHANGE_CORRECT
     //fprintf(stderr, "LCA idx: %zu",LCA_a->bfs_index);
     auto ref_score=get_parsimmony_score_only(src,dst,LCA,tree);
     assert(parsimony_score_change == ref_score);
 #endif
-    output_result(src, dst, LCA, parsimony_score_change, output,radius,callback);
+    output_result(src, dst, LCA, parsimony_score_change, output,radius,callback,major_alllele_count_changes_hist);
     return parsimony_score_change;
 }
 
@@ -139,7 +141,8 @@ int check_move_profitable_LCA(
     parent_added.reserve(parent_of_parent_added.size());
     parent_added .swap(parent_of_parent_added);
     //Go up the tree until there is no change to fitch set
-    check_parsimony_score_change_above_LCA(LCA, parsimony_score_change, parent_added, parent_of_parent_added);
+    std::vector<Node_With_Major_Allele_Set_Change> major_alllele_count_changes_hist;
+    check_parsimony_score_change_above_LCA(LCA, parsimony_score_change, parent_added, parent_of_parent_added,major_alllele_count_changes_hist);
 
 #ifdef DEBUG_PARSIMONY_SCORE_CHANGE_CORRECT
     //fprintf(stderr, "LCA idx: %zu",LCA_a->bfs_index);
@@ -148,6 +151,6 @@ int check_move_profitable_LCA(
 #endif
     std::vector<MAT::Node*> ignored;
     output_result(src, LCA, LCA, parsimony_score_change, output,
-                  radius,callback);
+                  radius,callback,major_alllele_count_changes_hist);
     return parsimony_score_change;
 }

--- a/src/matOptimize/Profitable_Moves_Enumerators/check_move_profitable_LCA.cpp
+++ b/src/matOptimize/Profitable_Moves_Enumerators/check_move_profitable_LCA.cpp
@@ -105,7 +105,9 @@ void check_parsimony_score_change_above_LCA(MAT::Node *curr_node, int &parsimony
         get_intermediate_nodes_mutations(
             curr_node,
             parent_added, parent_of_parent_added, parsimony_score_change);
-        major_alllele_count_changes_hist.push_back(Node_With_Major_Allele_Set_Change{curr_node,parent_of_parent_added});
+        if (!parent_of_parent_added.empty()) {
+            major_alllele_count_changes_hist.push_back(Node_With_Major_Allele_Set_Change{curr_node,parent_of_parent_added});    
+        }
         parent_added.swap(parent_of_parent_added);
         curr_node = curr_node->parent;
     }

--- a/src/matOptimize/Profitable_Moves_Enumerators/check_move_profitable_LCA.cpp
+++ b/src/matOptimize/Profitable_Moves_Enumerators/check_move_profitable_LCA.cpp
@@ -99,12 +99,13 @@ bool LCA_place_mezzanine(
 }
 void check_parsimony_score_change_above_LCA(MAT::Node *curr_node, int &parsimony_score_change,
         Mutation_Count_Change_Collection &parent_added,
-        Mutation_Count_Change_Collection &parent_of_parent_added) {
+        Mutation_Count_Change_Collection &parent_of_parent_added,std::vector<Node_With_Major_Allele_Set_Change>& major_alllele_count_changes_hist) {
     while (curr_node && (!parent_added.empty())) {
         parent_of_parent_added.clear();
         get_intermediate_nodes_mutations(
             curr_node,
             parent_added, parent_of_parent_added, parsimony_score_change);
+        major_alllele_count_changes_hist.push_back(Node_With_Major_Allele_Set_Change{curr_node,parent_of_parent_added});
         parent_added.swap(parent_of_parent_added);
         curr_node = curr_node->parent;
     }

--- a/src/matOptimize/Profitable_Moves_Enumerators/downward_integrated.cpp
+++ b/src/matOptimize/Profitable_Moves_Enumerators/downward_integrated.cpp
@@ -45,7 +45,9 @@ static bool output_not_LCA(Mutation_Count_Change_Collection &parent_added,
         get_intermediate_nodes_mutations(this_node,
                                          parent_added, parent_of_parent_added,
                                          parsimony_score_change);
-        major_alllele_count_changes_hist.push_back(Node_With_Major_Allele_Set_Change{this_node, parent_of_parent_added});
+        if (!parent_of_parent_added.empty()) {
+            major_alllele_count_changes_hist.push_back(Node_With_Major_Allele_Set_Change{this_node, parent_of_parent_added});        
+        }
         parent_added.swap(parent_of_parent_added);
         if (parent_added.empty()) {
             break;
@@ -64,7 +66,9 @@ static bool output_not_LCA(Mutation_Count_Change_Collection &parent_added,
                          src_side.allele_count_change_from_src,
                          parent_added, parent_of_parent_added,
                          parsimony_score_change);
-        major_alllele_count_changes_hist.push_back(Node_With_Major_Allele_Set_Change{src_side.LCA, parent_of_parent_added});
+        if (!parent_of_parent_added.empty()) {
+            major_alllele_count_changes_hist.push_back(Node_With_Major_Allele_Set_Change{src_side.LCA, parent_of_parent_added});
+        }
     }
     parent_added.swap(parent_of_parent_added);
     parent_of_parent_added.clear();

--- a/src/matOptimize/Profitable_Moves_Enumerators/downward_integrated.cpp
+++ b/src/matOptimize/Profitable_Moves_Enumerators/downward_integrated.cpp
@@ -26,6 +26,7 @@ static bool output_not_LCA(Mutation_Count_Change_Collection &parent_added,
                            ,bool do_continue
 #endif
                           ) {
+    std::vector<Node_With_Major_Allele_Set_Change> major_alllele_count_changes_hist(src_side.node_with_major_allele_set_change);
     if (use_bound&&lower_bound > src_side.out.score_change) {
 #ifndef CHECK_BOUND
         return false;
@@ -44,6 +45,7 @@ static bool output_not_LCA(Mutation_Count_Change_Collection &parent_added,
         get_intermediate_nodes_mutations(this_node,
                                          parent_added, parent_of_parent_added,
                                          parsimony_score_change);
+        major_alllele_count_changes_hist.push_back(Node_With_Major_Allele_Set_Change{this_node, parent_of_parent_added});
         parent_added.swap(parent_of_parent_added);
         if (parent_added.empty()) {
             break;
@@ -62,12 +64,13 @@ static bool output_not_LCA(Mutation_Count_Change_Collection &parent_added,
                          src_side.allele_count_change_from_src,
                          parent_added, parent_of_parent_added,
                          parsimony_score_change);
+        major_alllele_count_changes_hist.push_back(Node_With_Major_Allele_Set_Change{src_side.LCA, parent_of_parent_added});
     }
     parent_added.swap(parent_of_parent_added);
     parent_of_parent_added.clear();
     check_parsimony_score_change_above_LCA(
         src_side.LCA->parent, parsimony_score_change, parent_added,
-        parent_of_parent_added);
+        parent_of_parent_added,major_alllele_count_changes_hist);
 #ifdef CHECK_PAR_MAIN
     output_t temp;
     auto refout=individual_move(src_side.src, dst_node, src_side.LCA, temp);
@@ -102,7 +105,7 @@ static bool output_not_LCA(Mutation_Count_Change_Collection &parent_added,
     src_side.savings.total++;
 #endif
     return output_result(src_side.src, dst_node, src_side.LCA, parsimony_score_change,
-                         src_side.out,radius,callback);
+                         src_side.out,radius,callback,major_alllele_count_changes_hist);
 }
 struct go_descendant {};
 struct no_descendant {};

--- a/src/matOptimize/Profitable_Moves_Enumerators/upward_integrated.cpp
+++ b/src/matOptimize/Profitable_Moves_Enumerators/upward_integrated.cpp
@@ -18,7 +18,9 @@ void output_LCA(
     int par_score_change, const src_side_info &src_side, int radius_left,Move_Found_Callback& callback) {
     Mutation_Count_Change_Collection parent_of_parent_added;
     std::vector<Node_With_Major_Allele_Set_Change> major_alllele_count_changes_hist(src_side.node_with_major_allele_set_change);
-    major_alllele_count_changes_hist.push_back(Node_With_Major_Allele_Set_Change{src_side.LCA,allele_count_change_from_splitting_LCA});
+    if (!allele_count_change_from_splitting_LCA.empty()) {
+        major_alllele_count_changes_hist.push_back(Node_With_Major_Allele_Set_Change{src_side.LCA,allele_count_change_from_splitting_LCA});
+    }
     parent_of_parent_added.reserve(
         allele_count_change_from_splitting_LCA.size());
     auto actual_LCA=src_side.LCA->parent;
@@ -325,7 +327,9 @@ upward_integrated(src_side_info &src_side,
 
     output_LCA(split_allele_count_change_out, par_score_change_split_LCA+next_src_par_score,
                src_side, radius_left,callback);
-    src_side.node_with_major_allele_set_change.emplace_back(Node_With_Major_Allele_Set_Change{node, Mutation_Count_Change_Collection{mut_out.begin(),mut_out.end()}});
+    if(!mut_out.empty()){
+        src_side.node_with_major_allele_set_change.emplace_back(Node_With_Major_Allele_Set_Change{node, Mutation_Count_Change_Collection{mut_out.begin(),mut_out.end()}});
+    }
     return true;
 }
 template<typename T>

--- a/src/matOptimize/Profitable_Moves_Enumerators/upward_integrated.cpp
+++ b/src/matOptimize/Profitable_Moves_Enumerators/upward_integrated.cpp
@@ -17,6 +17,8 @@ void output_LCA(
     Mutation_Count_Change_Collection &allele_count_change_from_splitting_LCA,
     int par_score_change, const src_side_info &src_side, int radius_left,Move_Found_Callback& callback) {
     Mutation_Count_Change_Collection parent_of_parent_added;
+    std::vector<Node_With_Major_Allele_Set_Change> major_alllele_count_changes_hist(src_side.node_with_major_allele_set_change);
+    major_alllele_count_changes_hist.push_back(Node_With_Major_Allele_Set_Change{src_side.LCA,allele_count_change_from_splitting_LCA});
     parent_of_parent_added.reserve(
         allele_count_change_from_splitting_LCA.size());
     auto actual_LCA=src_side.LCA->parent;
@@ -25,7 +27,7 @@ void output_LCA(
     }
     check_parsimony_score_change_above_LCA(
         actual_LCA, par_score_change, allele_count_change_from_splitting_LCA,
-        parent_of_parent_added);
+        parent_of_parent_added,major_alllele_count_changes_hist);
     std::vector<MAT::Node *> ignored;
 #ifdef CHECK_PAR_MAIN
     output_t temp;
@@ -49,7 +51,7 @@ void output_LCA(
     }
 #endif
     output_result(src_side.src, actual_LCA, actual_LCA, par_score_change,
-                  src_side.out, radius_left,callback);
+                  src_side.out, radius_left,callback,major_alllele_count_changes_hist);
 }
 template<typename T>
 static void search_subtree_first_level(MAT::Node *node, MAT::Node *to_exclude,
@@ -323,6 +325,7 @@ upward_integrated(src_side_info &src_side,
 
     output_LCA(split_allele_count_change_out, par_score_change_split_LCA+next_src_par_score,
                src_side, radius_left,callback);
+    src_side.node_with_major_allele_set_change.emplace_back(Node_With_Major_Allele_Set_Change{node, Mutation_Count_Change_Collection{mut_out.begin(),mut_out.end()}});
     return true;
 }
 template<typename T>


### PR DESCRIPTION
It only includes nodes on the path from source to destination, excluding source and destination, because during the search phase we assume all moves will split the branch between the destination and the parent of the destination node, creating a new node. I am not sure how to pass this information to larch. (If it creates a zero-length branch, it will be cleaned up at the very end.)

Maybe wait until the larch team confirms it is useful to merge this?