### PR TITLE
Fix segv when get_subtree is called without keep_clade_annotations on tree with annotations

### DIFF
--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -1502,8 +1502,13 @@ Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::get_subtree (const Mutati
             if (subtree_parent == NULL) {
                 // for root node, need to size the annotations vector
                 Node* new_node = subtree.create_node(n->identifier, -1.0, num_annotations);
+                // but watch out for nodes that have fewer than expected annotations
+                size_t node_num_annotations = num_annotations;
+                if (node_num_annotations > n->clade_annotations.size()) {
+                    node_num_annotations = n->clade_annotations.size();
+                }
                 // need to assign any clade annotations which would belong to that root as well
-                for (size_t k = 0; k < n->clade_annotations.size(); k++) {
+                for (size_t k = 0; k < node_num_annotations; k++) {
                     if (n->clade_annotations[k] != "") {
                         new_node->clade_annotations[k] = n->clade_annotations[k];
                     }
@@ -1528,7 +1533,12 @@ Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::get_subtree (const Mutati
 
 
                 for (auto curr: par_to_node) {
-                    for (size_t k = 0; k < curr->clade_annotations.size(); k++) {
+                    // watch out for nodes that have fewer than expected annotations
+                    size_t node_num_annotations = num_annotations;
+                    if (node_num_annotations > curr->clade_annotations.size()) {
+                        node_num_annotations = curr->clade_annotations.size();
+                    }
+                    for (size_t k = 0; k < node_num_annotations; k++) {
                         if (curr->clade_annotations[k] != "") {
                             new_node->clade_annotations[k] = curr->clade_annotations[k];
                         }


### PR DESCRIPTION
@mdperry and I independently found a SEGV condition when switching to the latest version of usher/matUtils: when MAT::get_subtree is called _without_ keep_clade_annotations=true, and the tree contains clade annotations, get_subtree creates new nodes with clade_annotations size 0 but then attempts to copy the existing node's clade annotations.  This was an unintended side effect of 052cf4a6 (which solved a different problem that could occur when keep_clade_annotations=true is passed in).

The solution is to limit the loop that copies clade annotations into the new node to the minimum of num_annotations (which is 0 when keep_clade_annotations is false) and source node's clade_annotations.size(), so overrun of clade_annotations is prevented for both the new node and the existing node.