### PR TITLE
usher-sampled support MAPLE input

### DIFF
--- a/src/usher-sampled/driver/main.cpp
+++ b/src/usher-sampled/driver/main.cpp
@@ -393,11 +393,15 @@ int main(int argc, char **argv) {
     ;
     po::variables_map vm;
     //wait_debug();
+    bool have_error=false;
     try {
         po::store(po::command_line_parser(argc, argv).options(desc).run(), vm);
         po::notify(vm);
     } catch(std::exception &e) {
         // Return with error code 1 unless the user specifies help
+        have_error=true;
+    }
+    if (have_error||(options.vcf_filename==""&&(options.diff_file_name==""||options.reference_file_name==""))) {
         if (this_rank==0) {
             if (vm.count("version")) {
                 std::cout << "UShER " << std::endl;

--- a/src/usher-sampled/driver/main.cpp
+++ b/src/usher-sampled/driver/main.cpp
@@ -311,7 +311,6 @@ static int leader_thread(
         tree, options.out_options, 0, samples_clade, sample_start_idx, sample_end_idx, low_confidence_samples,position_wise_out);
     auto duration=std::chrono::steady_clock::now()-start_time;
     fprintf(stderr, "Took %ld msec\n",std::chrono::duration_cast<std::chrono::milliseconds>(duration).count());
-    MPI_Finalize();
     return 0;
 }
 void wait_debug();

--- a/src/usher-sampled/driver/main.cpp
+++ b/src/usher-sampled/driver/main.cpp
@@ -170,7 +170,15 @@ static int leader_thread(
     std::vector<mutated_t> position_wise_out_dup;
     std::vector<std::string> samples;
     const std::unordered_set<std::string> samples_in_condensed_nodes;
-    Sample_Input(options.vcf_filename.c_str(),samples_to_place,tree,position_wise_out,options.override_mutations,samples,samples_in_condensed_nodes);
+    if(options.diff_file_name!=""&&options.reference_file_name!=""){
+        load_diff_for_usher(options.diff_file_name.c_str(), samples_to_place, position_wise_out,tree,options.reference_file_name,samples);
+    }else {
+        if(options.vcf_filename==""){
+            fprintf(stderr, "Expect either VCF file or MAPLE file\n");
+            exit(EXIT_FAILURE);
+        }
+        Sample_Input(options.vcf_filename.c_str(),samples_to_place,tree,position_wise_out,options.override_mutations,samples,samples_in_condensed_nodes);
+    }
     samples_to_place.resize(std::min(samples_to_place.size(),options.first_n_samples));
     size_t sample_start_idx=samples_to_place[0].sample_idx;
     size_t sample_end_idx=samples_to_place.back().sample_idx+1;
@@ -261,7 +269,6 @@ static int leader_thread(
         return 0;
     }
     while (true) {
-        fprintf(stderr, "Parsimony score %zu\n",tree.get_parsimony_score());
         clean_tree_for_placement(tree);
         prep_tree(tree);
         if (process_count>1) {
@@ -327,7 +334,7 @@ int main(int argc, char **argv) {
     bool ignored_options;
     //std::vector<int> gdb_pids;
     desc.add_options()
-    ("vcf,v", po::value<std::string>(&options.vcf_filename)->required(),"Input VCF file (in uncompressed or gzip-compressed .gz format) [REQUIRED]")
+    ("vcf,v", po::value<std::string>(&options.vcf_filename),"Input VCF file (in uncompressed or gzip-compressed .gz format) [REQUIRED]")
     ("tree,t", po::value<std::string>(&options.tree_in)->default_value(""), "Input tree file")
     ("outdir,d", po::value<std::string>(&options.out_options.outdir)->default_value("."), "Output directory to dump output and log files [DEFAULT uses current directory]")
     ("load-mutation-annotated-tree,i",po::value<std::string>(&options.protobuf_in)->default_value(""),"Load mutation-annotated tree object")
@@ -361,6 +368,8 @@ int main(int argc, char **argv) {
      "Do not add new samples to the tree")
     ("detailed-clades,D", po::bool_switch(&options.out_options.detailed_clades), \
      "In clades.txt, write a histogram of annotated clades and counts across all equally parsimonious placements")
+    ("diff",po::value<std::string>(&options.diff_file_name),"diff file from MAPLE, to be used with reference sequence")
+    ("ref",po::value<std::string>(&options.reference_file_name),"reference sequence, only needed for MAPLE")
     ("threads,T",po::value<uint32_t>(&num_threads)->default_value(num_cores),num_threads_message.c_str())
     ("reduce-back-mutation,B",po::bool_switch(&options.out_options.redo_FS_Min_Back_Mutations)->default_value(false),
      "Reassign states of internal nodes to reduce back mutation count.")

--- a/src/usher-sampled/import_vcf.cpp
+++ b/src/usher-sampled/import_vcf.cpp
@@ -253,6 +253,15 @@ static void add_mutation(long output_idx, const MAT::Mutation &mut_template,
             mutations_out[mut_template.get_position()].push_back(std::make_pair(-output_idx, mut_nuc));
     }
 }
+static int parse_digit(FILE* fh,int& read){
+    int acc=0;
+    read=fgetc(fh);
+    while (isdigit(read)) {
+        acc=acc*10+(read-'0');
+        read=fgetc(fh);
+    }
+    return acc;
+}
 struct line_parser {
     Sampled_Tree_Mutations_t &header;
     mut_container_t& mutations_out;
@@ -511,4 +520,112 @@ void Sample_Input(const char *name, std::vector<Sample_Muts> &sample_mutations,
     done = true;
     progress_bar_cv.notify_all();
     progress_meter.join();
+}
+static void load_reference(std::string fasta_fname){
+    auto fh=fopen(fasta_fname.c_str(), "r");
+    char* seq_name=nullptr;
+    size_t seq_len=0;
+    auto nchar=getline(&seq_name, &seq_len, fh);
+    MAT::Mutation::chromosomes.emplace_back(seq_name+1,seq_name+nchar-1);
+    MAT::Mutation::chromosome_map.emplace(MAT::Mutation::chromosomes[0],0);
+    free(seq_name);
+    auto read=fgetc(fh);
+    MAT::Mutation::refs.push_back(0);
+    while (read!=EOF) {
+        if (read!='\n') {
+            auto parsed_nuc=MAT::get_nuc_id(read);
+            if (parsed_nuc==0xf) {
+                parsed_nuc=0;
+            }
+            MAT::Mutation::refs.push_back(parsed_nuc);
+        }
+        read=fgetc(fh);
+    }
+}
+typedef std::vector<mutated_t> mut_container_t;
+void load_diff_for_usher(
+    const char *input_path,std::vector<Sample_Muts>& all_samples,
+    mut_container_t& position_wise_out, MAT::Tree &tree, const std::string& fasta_fname,
+    std::vector<std::string> & samples) {
+    load_reference(fasta_fname);
+    position_wise_out.resize(MAT::Mutation::refs.size());
+    auto fh=fopen(input_path, "r");
+    int read;
+    int line_count=0;
+    bool do_add=true;
+    int samp_idx;
+    while (true) {
+        read=fgetc(fh);
+        if (read==EOF) {
+            return;
+        }
+        if (read=='>') {
+            std::string sample_name;
+            for(read=fgetc(fh);read!='\n';read=fgetc(fh)){
+            if (read==EOF) {
+                fprintf(stderr, "%d: unexpected EOF READ %s sofar\n",line_count, sample_name.c_str());
+                raise(SIGTRAP);
+            }
+            sample_name.push_back(read);
+            }
+            samples.push_back(sample_name);
+            auto node=tree.get_node(sample_name);
+            if (node != nullptr) {
+                fprintf(stderr, "WARNING: Sample %s already in the tree! Ignoring.\n\n", sample_name.c_str());
+                samp_idx=node->node_id;
+                do_add=false;
+            } else {
+                samp_idx=tree.map_samp_name_only(sample_name);
+                do_add=true;
+                all_samples.emplace_back();
+                all_samples.back().sample_idx=samp_idx;
+            }
+        }else {
+            
+            auto parsed_nuc=MAT::get_nuc_id(read);
+            if (parsed_nuc==0xf&&read!='n'&&read!='-') {
+                fprintf(stderr, "at line %d\n",line_count);
+                raise(SIGTRAP);
+            }
+            read=fgetc(fh);
+            if(read!='\t'){
+                fprintf(stderr, "%d:Expect tab, got %d:%c\n",line_count,read,read);
+                raise(SIGTRAP);
+            }
+            auto pos=parse_digit(fh,read);
+            if (parsed_nuc==0xf) {
+                if(read!='\t'){
+                    fprintf(stderr, "%d:n nuc, Expect tab, got %d:%c\n",line_count,read,read);
+                    raise(SIGTRAP);
+                }else {
+                    auto len=parse_digit(fh, read);
+                    if(do_add){
+                        all_samples.back().muts.emplace_back(pos,0,0xf);
+                        all_samples.back().muts.back().range=len-1;
+                    }
+                    for (int n_counter=0; n_counter<len; n_counter++) {
+                        position_wise_out[pos+n_counter].emplace_back(samp_idx,0xf);
+                    }
+                }
+            }else {
+                if(do_add){
+                    all_samples.back().muts.emplace_back(pos,0,parsed_nuc,MAT::Mutation::refs[pos]);
+                }
+                position_wise_out[pos].emplace_back(samp_idx,parsed_nuc);
+            }
+            if (read!='\n'&&read!=EOF) {
+                std::string temp;
+                while (read!='\n'&&read!=EOF) {
+                    temp.push_back(read);
+                    read=fgetc(fh);
+                }
+                fprintf(stderr, "%d:Got unrecongnized trialing :%s\n",line_count,temp.c_str());
+            }
+            if (read==EOF) {
+                return;
+            }
+        }
+
+        line_count++;
+    }
 }

--- a/src/usher-sampled/usher.hpp
+++ b/src/usher-sampled/usher.hpp
@@ -90,7 +90,7 @@ struct output_options {
     bool detailed_clades;
     bool redo_FS_Min_Back_Mutations;
 };
-void final_output(MAT::Tree& T,const output_options& options,int t_idx,std::vector<Clade_info>& assigned_clades,
+bool final_output(MAT::Tree& T,const output_options& options,int t_idx,std::vector<Clade_info>& assigned_clades,
                   size_t sample_start_idx,size_t sample_end_idx,std::vector<std::string>& low_confidence_samples,std::vector<mutated_t>& position_wise_out);
 void place_sample_leader(std::vector<Sample_Muts> &sample_to_place,
                          MAT::Tree &main_tree, int batch_size,
@@ -135,6 +135,8 @@ struct Leader_Thread_Options {
     int last_optimization_minutes;
     std::string vcf_filename;
     bool no_add;
+    std::string diff_file_name;
+    std::string reference_file_name;
 };
 int set_descendant_count(MAT::Node* root);
 void discretize_mutations(const std::vector<To_Place_Sample_Mutation> &in,
@@ -164,3 +166,7 @@ void place_sample_sequential(
     bool do_print, FILE *printer_out);
 void clean_up_leaf(std::vector<MAT::Node*>& dfs);
 void prep_tree(MAT::Tree &tree);
+void load_diff_for_usher(
+    const char *input_path,std::vector<Sample_Muts>& all_samples,
+    std::vector<mutated_t>& position_wise_out, MAT::Tree &tree,
+    const std::string& fasta_fname,std::vector<std::string> & samples);

--- a/src/usher-sampled/utils.cpp
+++ b/src/usher-sampled/utils.cpp
@@ -644,9 +644,10 @@ bool final_output(MAT::Tree &T, const output_options &options, int t_idx,
     fix_condensed_nodes(&T);
     //check_leaves(T);
     //MAT::save_mutation_annotated_tree(T, "before_post_processing.pb");
+    MPI_Finalize();
     int pid=output_newick(T, options,t_idx);
     if(!pid){
-        return false;
+        _exit(EXIT_SUCCESS);
     }
     // For each final tree write the path of mutations from tree root to the
     // sample for each newly placed sample

--- a/src/usher-sampled/utils.cpp
+++ b/src/usher-sampled/utils.cpp
@@ -541,7 +541,7 @@ static int output_newick(MAT::Tree& T,const output_options& options,int t_idx) {
         std::ofstream final_tree_file(final_tree_filename.c_str(), std::ofstream::out);
         T.write_newick_string(final_tree_file,T.root, true, true, options.retain_original_branch_len,true);
         final_tree_file.close();
-        exit(EXIT_SUCCESS);
+        return 0;
     } else {
         return pid;
     }
@@ -618,7 +618,7 @@ void print_annotation(const MAT::Tree &T, const output_options &options,
 
     fclose(annotations_file);
 }
-void final_output(MAT::Tree &T, const output_options &options, int t_idx,
+bool final_output(MAT::Tree &T, const output_options &options, int t_idx,
                   std::vector<Clade_info> &assigned_clades,
                   size_t sample_start_idx, size_t sample_end_idx,
                   std::vector<std::string> &low_confidence_samples,std::vector<mutated_t>& position_wise_out) {
@@ -645,6 +645,9 @@ void final_output(MAT::Tree &T, const output_options &options, int t_idx,
     //check_leaves(T);
     //MAT::save_mutation_annotated_tree(T, "before_post_processing.pb");
     int pid=output_newick(T, options,t_idx);
+    if(!pid){
+        return false;
+    }
     // For each final tree write the path of mutations from tree root to the
     // sample for each newly placed sample
     bool use_tree_idx = !options.only_one_tree;
@@ -733,7 +736,7 @@ void final_output(MAT::Tree &T, const output_options &options, int t_idx,
         //fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
     }
     wait(&pid);
-
+    return true;
 }
 /*static void check_repeats(const std::vector<Sample_Muts>& samples_to_place,size_t sample_start_idx){
     std::vector<bool> encountered(samples_to_place.size());


### PR DESCRIPTION
usher-sampled can read maple diff file through --diff argument and --ref argument (maple diff file do not contain reference allele). I am running out of letters for the single letter options, so they don't have a single letter option.