### PR TITLE
usher-sampled : Exit properly when there is no sample to place

### DIFF
--- a/src/usher-sampled/driver/main.cpp
+++ b/src/usher-sampled/driver/main.cpp
@@ -180,6 +180,10 @@ static int leader_thread(
         Sample_Input(options.vcf_filename.c_str(),samples_to_place,tree,position_wise_out,options.override_mutations,samples,samples_in_condensed_nodes);
     }
     samples_to_place.resize(std::min(samples_to_place.size(),options.first_n_samples));
+    if(samples_to_place.empty()){
+        fprintf(stderr,"No samples to place\n");
+        exit(EXIT_FAILURE);
+    }
     size_t sample_start_idx=samples_to_place[0].sample_idx;
     size_t sample_end_idx=samples_to_place.back().sample_idx+1;
     fprintf(stderr, "Sample start idx %zu, end index %zu\n",sample_start_idx,sample_end_idx);

--- a/src/usher-sampled/import_vcf.cpp
+++ b/src/usher-sampled/import_vcf.cpp
@@ -583,7 +583,7 @@ void load_diff_for_usher(
         }else {
             
             auto parsed_nuc=MAT::get_nuc_id(read);
-            if (parsed_nuc==0xf&&read!='n'&&read!='-') {
+            if (parsed_nuc==0xf&&read!='n'&&read!='N'&&read!='-') {
                 fprintf(stderr, "at line %d\n",line_count);
                 raise(SIGTRAP);
             }
@@ -594,19 +594,24 @@ void load_diff_for_usher(
             }
             auto pos=parse_digit(fh,read);
             if (parsed_nuc==0xf) {
+                int len;
                 if(read!='\t'){
+                    if(read=='\n'){
+                        len=1;
+                    }else{           
                     fprintf(stderr, "%d:n nuc, Expect tab, got %d:%c\n",line_count,read,read);
                     raise(SIGTRAP);
+                    }
                 }else {
-                    auto len=parse_digit(fh, read);
-                    if(do_add){
+                    len=parse_digit(fh, read);
+                }
+                if(do_add){
                         all_samples.back().muts.emplace_back(pos,0,0xf);
                         all_samples.back().muts.back().range=len-1;
                     }
                     for (int n_counter=0; n_counter<len; n_counter++) {
                         position_wise_out[pos+n_counter].emplace_back(samp_idx,0xf);
                     }
-                }
             }else {
                 if(do_add){
                     all_samples.back().muts.emplace_back(pos,0,parsed_nuc,MAT::Mutation::refs[pos]);


### PR DESCRIPTION
Also make diff format more permissive -- infer a 1 for -/N if missing.