### PR TITLE
branch-specific masking: compare par_nuc not ref_nuc

### DIFF
--- a/src/matUtils/mask.cpp
+++ b/src/matUtils/mask.cpp
@@ -188,7 +188,7 @@ bool match_mutations(MAT::Mutation* target, MAT::Mutation* query) {
         return false;
     }
     if (target->ref_nuc != 0b1111) {
-        if (target->ref_nuc != query->ref_nuc) {
+        if (target->par_nuc != query->par_nuc) {
             return false;
         }
     }


### PR DESCRIPTION
For reversion mutations in the tree, mut_nuc is the same as ref_nuc and par_nuc is the change being reverted.  `matUtils mask --mask-mutations` was comparing ref_nuc instead of par_nuc, so it was unable to recognize reversions specified in its input file that were present in the tree.  (For mutations parsed from the input file, ref_nuc is set to the same value as par_nuc, but that is not the case for mutations in the tree.)