### PR TITLE
new options for matUtils extract: --max-mut-density, --node-stats

### DIFF
--- a/src/matUtils/annotate.cpp
+++ b/src/matUtils/annotate.cpp
@@ -246,8 +246,13 @@ void parse_clade_mutations(const std::string& clade_mutations_filename,
             std::vector<std::string> mut_strings;
             MAT::string_split(path_el, ',', mut_strings);
             for (auto mut_string: mut_strings) {
+                if (mut_string == "") {
+                    continue;
+                }
                 MAT::Mutation *mut = MAT::mutation_from_string(mut_string);
                 if (mut == NULL) {
+                    fprintf(stderr, "Unable to parse mutation '%s' for %s element %s\n",
+                            mut_string.c_str(), clade.c_str(), path_el.c_str());
                     got_error = true;
                 } else {
                     if (std::find(mut_positions.begin(), mut_positions.end(), mut->position) != mut_positions.end()) {

--- a/src/matUtils/describe.cpp
+++ b/src/matUtils/describe.cpp
@@ -80,3 +80,130 @@ std::vector<std::string> all_nodes_paths(MAT::Tree* T) {
     }
     return dfs_strings;
 }
+
+void sort_if_necessary(std::vector<MAT::Mutation>& mutations) {
+    // If mutations are not already sorted by position, sort them.
+    bool is_sorted = true;
+    int prev_pos = 0;
+    for (auto mut: mutations) {
+        if (mut.position < prev_pos) {
+            is_sorted = false;
+            break;
+        }
+    }
+    if (! is_sorted) {
+        std::sort(mutations.begin(), mutations.end());
+    }
+}
+
+std::vector<MAT::Mutation> add_mutations(const std::vector<MAT::Mutation>& parent_muts,
+                                         const std::vector<MAT::Mutation>& node_muts) {
+    // Return a new vector that includes both parent_muts and node_muts, but collapsing multiple
+    // mutations at the same position.  Inputs must be sorted by position.  Output is sorted.
+    std::vector<MAT::Mutation> combined_muts;
+    if (parent_muts.size() == 0) {
+        combined_muts = node_muts;
+    } else if (node_muts.size() == 0) {
+        combined_muts = parent_muts;
+    } else {
+        size_t px = 0;
+        for (auto n: node_muts) {
+            while (parent_muts[px].position < n.position && px < parent_muts.size()) {
+                combined_muts.emplace_back(parent_muts[px]);
+                px++;
+            }
+            if (px < parent_muts.size()) {
+                if (parent_muts[px].position == n.position) {
+                    if (n.mut_nuc == parent_muts[px].par_nuc) {
+                        // They cancel each other out; don't add either to combined_muts.
+                    } else {
+                        MAT::Mutation mut;
+                        mut.par_nuc = parent_muts[px].par_nuc;
+                        mut.mut_nuc = n.mut_nuc;
+                        combined_muts.emplace_back(mut);
+                    }
+                    px++;
+                } else {
+                    combined_muts.emplace_back(n);
+                }
+            } else {
+                combined_muts.emplace_back(n);
+            }
+        }
+        while (px < parent_muts.size()) {
+            combined_muts.emplace_back(parent_muts[px]);
+            px++;
+        }
+    }
+    
+    return combined_muts;
+}
+
+size_t count_reversions(const std::vector<MAT::Mutation>& clade_muts,
+                        const std::vector<MAT::Mutation>& node_muts) {
+    // Return the number of reversions to reference from clade_muts in node_muts.
+    // Inputs must be sorted by position.
+    size_t rev_count = 0;
+    if (clade_muts.size() > 0 && node_muts.size() > 0) {
+        size_t cx = 0;
+        for (auto n: node_muts) {
+            while (clade_muts[cx].position < n.position && cx < clade_muts.size()) {
+                cx++;
+            }
+              if (cx < clade_muts.size() &&
+                  clade_muts[cx].position == n.position &&
+                  n.mut_nuc == clade_muts[cx].par_nuc) {
+                  rev_count++;
+              }
+        }
+    }
+    return rev_count;
+}
+
+void print_node_stats_r(Mutation_Annotated_Tree::Node* node, size_t& leaf_count, size_t& mut_count,
+                        const std::vector<MAT::Mutation>& parent_clade_muts,
+                        const std::vector<MAT::Mutation>& parent_muts, size_t parent_rev_count,
+                        std::ofstream& outfile) {
+    // Recursively descend from node, counting number of reversions since last annotated clade on
+    // the way down and tallying up leaf counts and total mut counts of descendants on the way up.
+    // Print stats for each leaf and internal node.
+    sort_if_necessary(node->mutations);
+    const std::vector<MAT::Mutation> my_muts = add_mutations(parent_muts, node->mutations);
+    bool is_clade_root = std::any_of(node->clade_annotations.begin(), node->clade_annotations.end(),
+                                     [](std::string& clade){ return clade != ""; });
+    size_t rev_count = is_clade_root ? 0 :
+      (parent_rev_count + count_reversions(parent_clade_muts, node->mutations));
+    if (node->children.size() > 0) {
+        size_t leaf_count_total = 0, mut_count_total = node->mutations.size();
+        const std::vector<MAT::Mutation>& clade_muts = is_clade_root ? my_muts : parent_clade_muts;
+        for (auto child: node->children) {
+            size_t leaf_count_child, mut_count_child;
+            print_node_stats_r(child, leaf_count_child, mut_count_child,
+                               clade_muts, my_muts, rev_count, outfile);
+            leaf_count_total += leaf_count_child;
+            mut_count_total += mut_count_child;
+        }
+        outfile << node->identifier << "\t" << leaf_count_total << "\t" << mut_count_total <<
+          "\t" << mut_count_total / (double)leaf_count_total << "\t" << rev_count << "\n";
+        leaf_count = leaf_count_total;
+        mut_count = mut_count_total;
+    } else {
+        leaf_count = 1;
+        mut_count = node->mutations.size();
+        outfile << node->identifier << "\t" << leaf_count << "\t" << mut_count <<
+          "\t" << mut_count << "\t" << rev_count << "\n";
+    }
+}
+
+void print_node_stats(Mutation_Annotated_Tree::Node* node, size_t& leaf_count, size_t& mut_count,
+                      std::ofstream& outfile) {
+    // Print out columns that can be used to determine the "aspect ratio" of each internal node's
+    // branch displayed as a rectangular tree: "tall and narrow" branches have many leaves with
+    // relatively few mutations, while "short and wide" branches have fewer leaves with relatively
+    // many mutations.  This can be used as a sort of branch-level quality filter.
+    // Also print out the number of reversions relative to the annotated clade for both internal
+    // nodes and leaves.
+    outfile << "node\tleaf_count\tmut_count\tmut_density\trev_from_lineage\n";
+    std::vector<MAT::Mutation> no_muts;
+    print_node_stats_r(node, leaf_count, mut_count, no_muts, no_muts, 0, outfile);
+}

--- a/src/matUtils/describe.hpp
+++ b/src/matUtils/describe.hpp
@@ -3,3 +3,4 @@
 std::vector<std::string> mutation_paths(MAT::Tree* T, std::vector<std::string> samples);
 std::vector<std::string> clade_paths(MAT::Tree* T);
 std::vector<std::string> all_nodes_paths(MAT::Tree* T);
+void print_node_stats(Mutation_Annotated_Tree::Node* node, size_t& leaf_count, size_t& mut_count, std::ofstream& outfile);

--- a/src/matUtils/select.cpp
+++ b/src/matUtils/select.cpp
@@ -334,6 +334,137 @@ std::vector<std::string> get_short_paths (MAT::Tree* T, std::vector<std::string>
     return good_samples;
 }
 
+void prune_except_clade_roots(Mutation_Annotated_Tree::Node* node, std::unordered_set<std::string>& samples_to_prune, std::unordered_set<std::string>& nodes_exempt, std::string& chopped_node, const size_t leaf_count_total, const size_t mut_count_total, const double mut_density) {
+    // Recursively descend node, adding IDs of all leaf descendants of node to samples_to_prune,
+    // unless node is a clade root (in that case print a message for now***) or is in nodes_exempt.
+    bool has_clade_annotation = false;
+    for (auto cann: node->clade_annotations) {
+        if (cann != "") {
+            has_clade_annotation = true;
+            fprintf(stderr, "Sparing node %s (from %s) because it has clade annotation %s\n", node->identifier.c_str(), chopped_node.c_str(), cann.c_str());
+            break;
+        }
+    }
+    if (! has_clade_annotation &&
+        nodes_exempt.find(node->identifier) == nodes_exempt.end()) {
+        if (node->children.size() == 0) {
+            samples_to_prune.insert(node->identifier);
+        } else {
+            for (auto child: node->children) {
+              prune_except_clade_roots(child, samples_to_prune, nodes_exempt, chopped_node, leaf_count_total, mut_count_total, mut_density);
+            }
+        }
+    }
+}
+
+void add_nodes_to_set(Mutation_Annotated_Tree::Node* node, std::unordered_set<std::string>& set) {
+    // Recursively descend node, adding IDs of all internal nodes to set.
+    if (node->children.size() > 0) {
+        set.insert(node->identifier);
+        for (auto child: node->children) {
+            add_nodes_to_set(child, set);
+        }
+    }
+}
+
+void filter_mut_density_helper(Mutation_Annotated_Tree::Node* node, Mutation_Annotated_Tree::Tree* T, const double max_mut_density, const std::unordered_map<std::string, size_t>& node_leaf_counts, size_t& leaf_count, size_t& mut_count, std::unordered_set<std::string>& samples_to_prune, std::unordered_set<std::string>& nodes_exempt) {
+    // Recursively descend node, identifying samples to prune because their branches have too-high
+    // mutation density and no redeeming qualities such as being an annotated clade.
+    if (node->children.size() > 0) {
+        // First, exempt all descendants of clade root nodes with small leaf count from pruning
+        for (auto cann: node->clade_annotations) {
+            if (cann != "") {
+                size_t pre_prune_count = node_leaf_counts.at(node->identifier);
+                if (pre_prune_count < 150) {
+                    add_nodes_to_set(node, nodes_exempt);
+                }
+                break;
+            }
+        }
+        // Internal node: sum up counts of children to get mutation density
+        bool this_node_exempt = (nodes_exempt.find(node->identifier) != nodes_exempt.end());
+        size_t leaf_count_total = 0, mut_count_total = 0, own_mut_count = node->mutations.size();
+        for (auto child: node->children) {
+            if (!this_node_exempt && child->children.size() == 0) {
+                // Special case for leaf child of node that's not already exempt: prune if
+                // leaf mutation count exceeds max_mut_density.
+                size_t child_mut_count = child->mutations.size();
+                if (child_mut_count > max_mut_density) {
+                    samples_to_prune.insert(child->identifier);
+                } else {
+                    leaf_count_total++;
+                    mut_count_total += child_mut_count;
+                }
+            } else {
+                size_t leaf_count_child, mut_count_child;
+                filter_mut_density_helper(child, T, max_mut_density, node_leaf_counts, leaf_count_child, mut_count_child, samples_to_prune, nodes_exempt);
+                leaf_count_total += leaf_count_child;
+                mut_count_total += mut_count_child;
+            }
+        }
+        // If all children have been pruned, then this node has effectively been pruned;
+        // just return zero counts.
+        if (leaf_count_total == 0) {
+            leaf_count = 0;
+            mut_count = 0;
+        } else {
+            // Treat mutations at this node specially for purposes of computing mutation density:
+            // divide by leaf count to avoid penalizing a long branch to a tight cluster.
+            double own_mut_contribution = own_mut_count / (double)leaf_count_total;
+            double mut_density = (own_mut_contribution + mut_count_total) / (double)leaf_count_total;
+            if (mut_density > max_mut_density) {
+                // Remove all descendants of this node (unless exempt) and return zero counts
+                prune_except_clade_roots(node, samples_to_prune, nodes_exempt, node->identifier, leaf_count_total, mut_count_total, mut_density);
+                leaf_count = 0;
+                mut_count = 0;
+            } else {
+                leaf_count = leaf_count_total;
+                // Include own_mut_count in return value without scaling
+                mut_count = mut_count_total + own_mut_count;
+                // Exempt this node from pruning if it has a very low mut_density
+                if (mut_density < 1 / max_mut_density) {
+                    nodes_exempt.insert(node->identifier);
+                }
+            }
+        }
+    } else {
+        // Leaf node: just return counts
+        leaf_count = 1;
+        mut_count = node->mutations.size();
+    }
+}
+
+size_t get_leaf_counts(Mutation_Annotated_Tree::Node* node, std::unordered_map<std::string, size_t>& node_leaf_counts) {
+    // Recursively descend the tree to find and store leaf counts for each node.
+    size_t leaf_count = 0;
+    if (node->children.size() == 0) {
+        leaf_count = 1;
+    } else {
+        for (auto child: node->children) {
+            leaf_count += get_leaf_counts(child, node_leaf_counts);
+        }
+    }
+    node_leaf_counts.insert({node->identifier, leaf_count});
+    return leaf_count;
+}
+
+std::unordered_set<std::string> filter_mut_density(Mutation_Annotated_Tree::Tree* T, std::unordered_set<std::string>& samples_to_check, double max_mut_density) {
+    // Prune branches that have a too-high mutation density, i.e. ratio of total mutations to number
+    // of leaves.  Don't prune annotated clades or branches with very low mutation density.
+    std::unordered_set<std::string> samples_to_prune, nodes_exempt;
+    std::unordered_map<std::string, size_t> node_leaf_counts;
+    get_leaf_counts(T->root, node_leaf_counts);
+    size_t leaf_count, mut_count;
+    filter_mut_density_helper(T->root, T, max_mut_density, node_leaf_counts, leaf_count, mut_count, samples_to_prune, nodes_exempt);
+    std::unordered_set<std::string> samples_to_keep;
+    for (auto sample = samples_to_check.begin();  sample != samples_to_check.end();  sample++) {
+        if (samples_to_prune.find(*sample) == samples_to_prune.end()) {
+            samples_to_keep.insert(*sample);
+        }
+    }
+    return samples_to_keep;
+}
+
 std::unordered_map<std::string,std::unordered_map<std::string,std::string>> read_metafile(std::string metainf, std::set<std::string> samples_to_use) {
     std::ifstream infile(metainf);
     if (!infile) {

--- a/src/matUtils/select.hpp
+++ b/src/matUtils/select.hpp
@@ -15,3 +15,4 @@ std::vector<std::string> get_sample_match(MAT::Tree* T, std::vector<std::string>
 std::vector<std::string> fill_random_samples(MAT::Tree* T, std::vector<std::string> current_samples, size_t target_size, bool lca_limit = false);
 std::vector<std::string> get_mrca_samples(MAT::Tree* T, std::vector<std::string> current_samples);
 std::pair<std::vector<std::string>, size_t> get_closest_samples(MAT::Tree* T, std::string nid, bool fixed_k, size_t k);
+std::unordered_set<std::string> filter_mut_density(Mutation_Annotated_Tree::Tree* T, std::unordered_set<std::string>& samples_to_check, double max_mut_density);


### PR DESCRIPTION
I added two options to matUtils extract to prune problematic sequences and branches from the SARS-CoV-2 tree before making a minimized tree for use with pangolin:
* `--node-stats filename` writes out various statistics of each internal node and sample, including the number of reversions to reference since the most recent ancestor annotated as a clade/lineage root.  (For recent pangolin data releases, I've been pruning samples with 2 or more reversions since lineage root.)
* `--max-mutation-density D` removes samples descended from nodes whose "mutation density" (sum of mutation counts divided by number of leaves) is greater than D (I've been using D=2 for pangolin), with several exceptions:
  * don't mark an annotated clade root for removal even if it or an ancestor has a high mutation density
  * keep samples descended from a node with mutation density < 1/D even if an ancestor of that clade is marked for removal, so tight clusters are kept even if on an otherwise poor-quality branch
  * keep all samples from annotated clades with fewer than 150 leaves (may want to add an option to set that someday)
  * divide an internal node's own mutation count by its leaf count when summing with descendants' mutation counts, so we don't over-penalize one long branch to a tight cluster.
