### PR TITLE
Fix subtree extraction && fork for newick writing

### DIFF
--- a/src/matOptimize/mutation_annotated_tree.cpp
+++ b/src/matOptimize/mutation_annotated_tree.cpp
@@ -528,7 +528,7 @@ struct NodeDist {
                     }
                 };
 class Least_N{
-    int cur_max;
+    //int cur_max;
     public:
     std::vector<NodeDist> nodes;
     size_t n;
@@ -545,15 +545,15 @@ class Least_N{
                 remaining_nodes.push_back(nodes.back().node);
                 nodes.back()=to_add;
                 std::push_heap(nodes.begin(),nodes.end());
-                if((int)nodes[0].num_mut>cur_max){
+                /*if((int)nodes[0].num_mut>cur_max){
                     raise(SIGTRAP);
                 }
-                cur_max=nodes[0].num_mut;
+                cur_max=nodes[0].num_mut;*/
             }
         }else {
             nodes.emplace_back(to_add);
             std::make_heap(nodes.begin(),nodes.end());
-            cur_max=nodes[0].num_mut;
+            //cur_max=nodes[0].num_mut;
         }
     }
 };
@@ -660,7 +660,6 @@ void Mutation_Annotated_Tree::get_random_sample_subtrees (const Mutation_Annotat
         trees_to_extract.emplace_back();
         auto& curr_tree=trees_to_extract.back();
         curr_tree.leaves_to_keep.reserve(subtree_size);
-        fprintf(stderr, "preping tree %zu\n", trees_to_extract.size());
         // Keep moving up the tree till a subtree of required size is
         // found
         auto anc=samples[i];
@@ -685,8 +684,7 @@ void Mutation_Annotated_Tree::get_random_sample_subtrees (const Mutation_Annotat
                 }
 
                 Least_N selected;
-                fprintf(stderr, "curr subtree size %zu\n",curr_tree.leaves_to_keep.size());
-                selected.n=nearest_subtree_size>curr_tree.leaves_to_keep.size()?nearest_subtree_size>curr_tree.leaves_to_keep.size():0;
+                selected.n=nearest_subtree_size>curr_tree.leaves_to_keep.size()?nearest_subtree_size-curr_tree.leaves_to_keep.size():0;
                 selected.nodes.reserve(selected.n);
                 selected.remaining_nodes.reserve(num_leaves-curr_tree.leaves_to_keep.size());
                 gather_nodes(anc, last_anc, selected, 0);
@@ -694,7 +692,7 @@ void Mutation_Annotated_Tree::get_random_sample_subtrees (const Mutation_Annotat
                     curr_tree.add_leave(n.node,sample_pos,displayed_samples);
                 }
                 to_extract_info_back_inserter inserter{curr_tree,sample_pos,displayed_samples};
-                std::sample(selected.remaining_nodes.begin(), selected.remaining_nodes.end(), inserter, random_subtree_size, std::default_random_engine{});
+                std::sample(selected.remaining_nodes.begin(), selected.remaining_nodes.end(), inserter, subtree_size-curr_tree.leaves_to_keep.size(), std::default_random_engine{});
             } else {
                 for (auto l: T.get_leaves(anc)) {
                      if (curr_tree.leaves_to_keep.size() == subtree_size) {
@@ -703,15 +701,6 @@ void Mutation_Annotated_Tree::get_random_sample_subtrees (const Mutation_Annotat
                     curr_tree.add_leave(l,sample_pos,displayed_samples);
                 
                 }
-            }
-            bool found=false;
-            for(auto &node: curr_tree.to_display_samples){
-                if(node==samples[i]){
-                    found=true;
-                }
-            }
-            if(!found){
-                raise(SIGTRAP);
             }
             break;
         }

--- a/src/matOptimize/mutation_annotated_tree.hpp
+++ b/src/matOptimize/mutation_annotated_tree.hpp
@@ -631,7 +631,7 @@ class Tree {
     void condense_leaves(std::vector<std::string> = std::vector<std::string>());
     void uncondense_leaves();
     std::string get_clade_assignment (const Node* n, int clade_id, bool include_self) const;
-    std::vector<Node*> get_leaves(const Node* n=nullptr) const;
+    std::vector<Node*> get_leaves(Node* n=nullptr) const;
     void populate_ignored_range();
     size_t get_max_level();
     friend class Node;

--- a/src/usher-sampled/driver/client-example.c
+++ b/src/usher-sampled/driver/client-example.c
@@ -40,8 +40,8 @@ static void send_args(FILE* f, int argc, char** argv){
 int main (int argc, char** argv){
     FILE* fh=make_f(argv[1]);
     char *cmd[] = { "ignored", "-v", argv[2], "-i", argv[3], "-d", "out",
-                "-k", "50", "-K", "50", "-u","--no-ignore-prefix","user_"};
-    send_args(fh, 14, cmd);
+                "-k", "500", "-u","--no-ignore-prefix","user_"};
+    send_args(fh, 12, cmd);
     char* line=NULL;
     size_t capacity=0;
     while (getline(&line, &capacity, fh)>0) {


### PR DESCRIPTION
* Revert back to using a process for newick writing. I forgot that the tree is getting condensed while writing pb.
* Parallelize subtree extraction, and fix subtree that does not contain any new sample.