### PR TITLE
Use at least 2 threads for usher-sampled

### DIFF
--- a/src/usher-sampled/driver/main.cpp
+++ b/src/usher-sampled/driver/main.cpp
@@ -429,6 +429,7 @@ int main(int argc, char **argv) {
     if (options.initial_optimization_radius<=0) {
         options.parsimony_threshold=INT_MAX;
     }
+    num_threads=std::max(2,num_threads);
     options.desired_optimization_msec=optimiation_minutes*60000;
     fprintf(stderr, "Num threads %d\n",num_threads);
 #ifdef __linux

--- a/src/usher-sampled/driver/main.cpp
+++ b/src/usher-sampled/driver/main.cpp
@@ -429,7 +429,7 @@ int main(int argc, char **argv) {
     if (options.initial_optimization_radius<=0) {
         options.parsimony_threshold=INT_MAX;
     }
-    num_threads=std::max(2,num_threads);
+    num_threads=std::max(2u,num_threads);
     options.desired_optimization_msec=optimiation_minutes*60000;
     fprintf(stderr, "Num threads %d\n",num_threads);
 #ifdef __linux


### PR DESCRIPTION
Usher-sampled needs one thread for tree modifications and at least another one for search. If -T1 is specified, it will deadlock.