### PR TITLE
removed "-defaults" channel

### DIFF
--- a/install/environment.yml
+++ b/install/environment.yml
@@ -1,6 +1,5 @@
 name: usher
 channels:
-  - defaults                                                                                                                                                                                                    
   - conda-forge
   - bioconda
   - anaconda


### PR DESCRIPTION
Removing the defaults channel resolves build issues currently affecting Ubuntu 22.04 and 20.04. I believe the reason is that there is a conflict between one of the defaults channel compilers and TBB or another package. The conda forge version does not produce the same error and builds correctly.