### PR TITLE
--haplotype rework and metadata loading flag

### DIFF
--- a/src/matUtils/select.cpp
+++ b/src/matUtils/select.cpp
@@ -465,7 +465,7 @@ std::unordered_set<std::string> filter_mut_density(Mutation_Annotated_Tree::Tree
     return samples_to_keep;
 }
 
-std::unordered_map<std::string,std::unordered_map<std::string,std::string>> read_metafile(std::string metainf, std::set<std::string> samples_to_use) {
+std::unordered_map<std::string,std::unordered_map<std::string,std::string>> read_metafile(std::string metainf, std::set<std::string> samples_to_use, bool load_all) {
     std::ifstream infile(metainf);
     if (!infile) {
         fprintf(stderr, "ERROR: Could not open the file: %s!\n", metainf.c_str());
@@ -493,7 +493,7 @@ std::unordered_map<std::string,std::unordered_map<std::string,std::string>> read
             first = false;
         } else {
             for (size_t i=1; i < words.size(); i++) {
-                if (samples_to_use.find(words[0]) != samples_to_use.end()) {
+                if ((samples_to_use.find(words[0]) != samples_to_use.end()) || (load_all)) {
                     metamap[keys[i]][words[0]] = words[i];
                 }
             }

--- a/src/matUtils/select.hpp
+++ b/src/matUtils/select.hpp
@@ -10,7 +10,7 @@ std::vector<std::string> sample_intersect (std::unordered_set<std::string> sampl
 std::vector<std::string> get_nearby (MAT::Tree* T, std::string sample_id, int number_to_get);
 std::vector<std::string> get_short_steppers(MAT::Tree* T, std::vector<std::string> samples_to_check, int max_mutations);
 std::vector<std::string> get_short_paths(MAT::Tree* T, std::vector<std::string> samples_to_check, int max_path);
-std::unordered_map<std::string,std::unordered_map<std::string,std::string>> read_metafile(std::string metainf, std::set<std::string> samples_to_use);
+std::unordered_map<std::string,std::unordered_map<std::string,std::string>> read_metafile(std::string metainf, std::set<std::string> samples_to_use, bool load_all = false);
 std::vector<std::string> get_sample_match(MAT::Tree* T, std::vector<std::string> samples_to_check, std::string substring);
 std::vector<std::string> fill_random_samples(MAT::Tree* T, std::vector<std::string> current_samples, size_t target_size, bool lca_limit = false);
 std::vector<std::string> get_mrca_samples(MAT::Tree* T, std::vector<std::string> current_samples);

--- a/src/matUtils/summary.cpp
+++ b/src/matUtils/summary.cpp
@@ -184,7 +184,6 @@ std::map<std::map<int,int8_t>,size_t> count_haplotypes(MAT::Tree* T) {
     //count and dynamic implementation dictionaries.
     std::map<hapset,size_t> hapcount;
     std::map<std::string,hapset> hapmap;
-    //proceed in breath first order.
     for (auto s: T->depth_first_expansion()) {
         hapset mset; 
         if (!s->is_root()) {
@@ -251,7 +250,7 @@ void write_haplotype_table(MAT::Tree* T, std::string filename) {
     for (auto const &hapc : hapmap) {
         std::ostringstream msetstr;
         for (auto m: hapc.first) {
-            msetstr << std::to_string(m.first) << MAT::get_nuc(m.second) << ",";
+            msetstr << m.first << MAT::get_nuc(m.second) << ",";
         }
         std::string final_str = msetstr.str();
         final_str.pop_back();

--- a/src/matUtils/summary.cpp
+++ b/src/matUtils/summary.cpp
@@ -178,15 +178,21 @@ void write_translate_table(MAT::Tree* T, std::string output_filename, std::strin
     fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
 }
 
-std::map<std::set<std::string>,size_t> count_haplotypes(MAT::Tree* T) {
-    std::map<std::set<std::string>,size_t> hapmap;
+std::map<std::set<MAT::Mutation*>,size_t> count_haplotypes(MAT::Tree* T) {
+    std::map<std::set<MAT::Mutation*>,size_t> hapmap;
     //naive method. for each sample, rsearch along the history to collect each of its mutations
     //and add those to the set. At the end, add that set to the hapcount keys if its not there, and increment.
     for (auto s: T->get_leaves()) {
-        std::set<std::string> mset;
+        std::set<MAT::Mutation*> mset;
         for (auto a: T->rsearch(s->identifier, true)) {
             for (auto m: a->mutations) {
-                mset.insert(m.get_string());
+                for (auto cm: mset){
+                    if ((cm->par_nuc == m.mut_nuc) && (cm->position == m.position)) {
+                        mset.erase(cm);
+                    } else {
+                        mset.insert(&m);
+                    }
+                }
             }
         }
         if (hapmap.find(mset) == hapmap.end()) {
@@ -229,7 +235,7 @@ void write_haplotype_table(MAT::Tree* T, std::string filename) {
     for (auto const &hapc : hapmap) {
         std::ostringstream msetstr;
         for (auto m: hapc.first) {
-            msetstr << m << ",";
+            msetstr << m->get_string() << ",";
         }
         std::string final_str = msetstr.str();
         final_str.pop_back();

--- a/src/matUtils/summary.cpp
+++ b/src/matUtils/summary.cpp
@@ -184,14 +184,14 @@ std::map<std::map<int,int8_t>,size_t> count_haplotypes(MAT::Tree* T) {
     //count and dynamic implementation dictionaries.
     //dynamic uses pointers to unique haplotypes to save on space.
     std::map<hapset,size_t> hapcount;
-    std::map<std::string,hapset*> hapmap;
+    std::map<std::string,hapset> hapmap;
     //proceed in breath first order.
-    for (auto s: T->breadth_first_expansion()) {
+    for (auto s: T->depth_first_expansion()) {
         //get the parent information, if it exists.
-        hapset mset;
-        auto parent = hapmap.find(s->parent->identifier);
-        if (parent != hapmap.end()) {
-            mset = *parent->second;
+
+        hapset mset; 
+        if (!s->is_root()) {
+            mset = hapmap[s->parent->identifier];
         }
         //update it for this node.
         for (auto m: s->mutations) { 
@@ -205,10 +205,8 @@ std::map<std::map<int,int8_t>,size_t> count_haplotypes(MAT::Tree* T) {
             hapcount[mset]++;
         } else { 
             //otherwise, store the current mset
-            hapmap[s->identifier] = &mset;
+            hapmap[s->identifier] = mset;
         }
-        //free memory- in breadth-first, grandparent information is unneeded, as all of its children have been traversed.
-        hapmap.pop(s->parent->parent->identifier)
     }
     return hapcount;
 }

--- a/src/matUtils/summary.cpp
+++ b/src/matUtils/summary.cpp
@@ -232,7 +232,6 @@ void write_haplotype_table(MAT::Tree* T, std::string filename) {
     for (auto const &hapc : hapmap) {
         std::ostringstream msetstr;
         for (auto m: hapc.first) {
-            // msetstr << m->get_string() << ",";
             msetstr << m.first << MAT::get_nuc(m.second) << ",";
         }
         std::string final_str = msetstr.str();

--- a/src/matUtils/summary.cpp
+++ b/src/matUtils/summary.cpp
@@ -182,20 +182,26 @@ std::map<std::map<int,int8_t>,size_t> count_haplotypes(MAT::Tree* T) {
     //define a special type- coordinate-state map.
     typedef std::map<int,int8_t> hapset;
     //count and dynamic implementation dictionaries.
-    //dynamic uses pointers to unique haplotypes to save on space.
     std::map<hapset,size_t> hapcount;
     std::map<std::string,hapset> hapmap;
     //proceed in breath first order.
     for (auto s: T->depth_first_expansion()) {
-        //get the parent information, if it exists.
-
         hapset mset; 
         if (!s->is_root()) {
             mset = hapmap[s->parent->identifier];
         }
         //update it for this node.
-        for (auto m: s->mutations) { 
-            mset[m.position] = m.mut_nuc;
+        for (auto m: s->mutations) {
+            if (m.mut_nuc == m.ref_nuc) {
+                //reversion to reference, get rid of any change at this position.
+                auto iter = mset.find(m.position);
+                if (iter != mset.end()) {
+                    mset.erase(iter);
+                }
+            } else {
+                //update the haplotype.
+                mset[m.position] = m.mut_nuc;
+            }
         }
         //if this node is a leaf, increment the haplotype's counter.
         if (s->is_leaf()) {

--- a/src/matUtils/summary.hpp
+++ b/src/matUtils/summary.hpp
@@ -6,7 +6,7 @@ void write_clade_table(MAT::Tree* T, std::string filename);
 void write_mutation_table(MAT::Tree* T, std::string filename);
 void write_translate_table(MAT::Tree* T, std::string output_filename, std::string gtf_filename, std::string fasta_filename);
 void write_aberrant_table(MAT::Tree* T, std::string filename);
-std::map<std::map<size_t,char>,size_t> count_haplotypes(MAT::Tree* T);
+std::map<std::map<int,int8_t>,size_t> count_haplotypes(MAT::Tree* T);
 void write_haplotype_table(MAT::Tree* T, std::string filename);
 void write_sample_clades_table (MAT::Tree* T, std::string sample_clades);
 void translate_main(MAT::Tree *T, std::string output_filename, std::string gff_filename, std::string fasta_filename );

--- a/src/matUtils/summary.hpp
+++ b/src/matUtils/summary.hpp
@@ -6,7 +6,7 @@ void write_clade_table(MAT::Tree* T, std::string filename);
 void write_mutation_table(MAT::Tree* T, std::string filename);
 void write_translate_table(MAT::Tree* T, std::string output_filename, std::string gtf_filename, std::string fasta_filename);
 void write_aberrant_table(MAT::Tree* T, std::string filename);
-std::map<std::set<MAT::Mutation*>,size_t> count_haplotypes(MAT::Tree* T);
+std::map<std::map<size_t,char>,size_t> count_haplotypes(MAT::Tree* T);
 void write_haplotype_table(MAT::Tree* T, std::string filename);
 void write_sample_clades_table (MAT::Tree* T, std::string sample_clades);
 void translate_main(MAT::Tree *T, std::string output_filename, std::string gff_filename, std::string fasta_filename );

--- a/src/matUtils/summary.hpp
+++ b/src/matUtils/summary.hpp
@@ -6,7 +6,7 @@ void write_clade_table(MAT::Tree* T, std::string filename);
 void write_mutation_table(MAT::Tree* T, std::string filename);
 void write_translate_table(MAT::Tree* T, std::string output_filename, std::string gtf_filename, std::string fasta_filename);
 void write_aberrant_table(MAT::Tree* T, std::string filename);
-std::map<std::set<std::string>,size_t> count_haplotypes(MAT::Tree* T);
+std::map<std::set<MAT::Mutation*>,size_t> count_haplotypes(MAT::Tree* T);
 void write_haplotype_table(MAT::Tree* T, std::string filename);
 void write_sample_clades_table (MAT::Tree* T, std::string sample_clades);
 void translate_main(MAT::Tree *T, std::string output_filename, std::string gff_filename, std::string fasta_filename );


### PR DESCRIPTION
This PR addresses two issues. 

First, it addresses https://github.com/yatisht/usher/issues/303. Typically, only metadata for samples in the users query set is loaded into memory. This was originally implemented to reduce the memory footprint of our approach. However, in cases with -N, -K, and similar, users may want full metadata to be available for any and all samples in their output, including non-query context samples. Accordingly, I have added a flag (without a single letter accompanying it) `--load-all-metadata` to matUtils extract indicating that all available metadata should be loaded and available for output. 

Second, it addresses https://github.com/yatisht/usher/issues/326. This is a significant rework of the implementation and output of `matUtils summary --haplotype`. It is now dynamically computed, significantly reducing runtime, and instead of representing haplotypes as unordered mutational paths, they are now represented as location-state strings in a set (e.g. '56A,60G' means that a haplotype where position 56 is A, position 60 is G, and the rest are reference). 