### PR TITLE
matUtils updates: new subcommand "fix"; improvements to MAT::Tree:move_node and mask --move-nodes

### DIFF
--- a/src/matUtils/fix.cpp
+++ b/src/matUtils/fix.cpp
@@ -1,0 +1,123 @@
+#include "fix.hpp"
+
+// Default: move node if it has at least 1 descendent
+int default_min_descendent_count = 1;
+int default_iterations = 1;
+
+po::variables_map parse_fix_command(po::parsed_options parsed) {
+
+    po::variables_map vm;
+    po::options_description filt_desc("fix options");
+    filt_desc.add_options()
+    ("input-mat,i", po::value<std::string>()->required(),
+     "Input mutation-annotated tree file [REQUIRED]")
+    ("output-mat,o", po::value<std::string>()->required(),
+     "Path to output fixed mutation-annotated tree file [REQUIRED]")
+    ("iterations,n", po::value<int>()->default_value(default_iterations),
+     "Number of iterations to run")
+    ("min-descendent-count,c", po::value<int>()->default_value(default_min_descendent_count),
+     "Minimum number of descendents required to move a node")
+    ("help,h", "Print help messages");
+    // Collect all the unrecognized options from the first pass. This will include the
+    // (positional) command name, so we need to erase that.
+    std::vector<std::string> opts = po::collect_unrecognized(parsed.options, po::include_positional);
+    opts.erase(opts.begin());
+
+    // Run the parser, with try/catch for help
+    try {
+        po::store(po::command_line_parser(opts)
+                  .options(filt_desc)
+                  .run(), vm);
+        po::notify(vm);
+    } catch(std::exception &e) {
+        std::cerr << filt_desc << std::endl;
+        // Return with error code 1 unless the user specifies help
+        if (vm.count("help"))
+            exit(0);
+        else
+            exit(1);
+    }
+    return vm;
+}
+
+static int fix_grandparent_reversions_r(MAT::Tree *T, MAT::Node *node, MAT::Node *ggp_node,
+                                        MAT::Node *gp_node, MAT::Node *p_node,
+                                        int min_descendent_count) {
+    // Recursively scan the tree for cases of grandparent-reversion, i.e. N > A > B > revA;
+    // when a case like that is found, move the revA node to be a child of N having mutation B.
+    int descendent_count = 0;
+    // First recursively descend to children, looking each one up by identifier in case it has
+    // been removed by the time we get to it:
+    std::vector<std::string> child_ids;
+    for (auto child: node->children) {
+        child_ids.push_back(child->identifier);
+    }
+    for (auto child_id: child_ids) {
+        MAT::Node *child = T->get_node(child_id);
+        if (child != NULL) {
+            descendent_count += fix_grandparent_reversions_r(T, child, gp_node, p_node, node,
+                                                             min_descendent_count);
+        }
+    }
+    // Now determine whether this node has only one mutation that reverts its grandparent's only
+    // mutation; if so (and if parent has only one mut, othw parsimony score would increase),
+    // then move this node to be a child of its great-grandparent, with only its parent's mut.
+    if (ggp_node != NULL && node->mutations.size() == 1 && gp_node->mutations.size() == 1 &&
+        p_node->mutations.size() == 1) {
+        MAT::Mutation node_mut = node->mutations.front();
+        MAT::Mutation gp_mut = gp_node->mutations.front();
+        if (node_mut.position == gp_mut.position &&
+            node_mut.chrom == gp_mut.chrom &&
+            node_mut.mut_nuc == gp_mut.par_nuc &&
+            node_mut.par_nuc == gp_mut.mut_nuc &&
+            descendent_count >= min_descendent_count) {
+            fprintf(stderr, "Node %s mutation %s reverts grandparent %s's %s%s, moving to %s with %s (%d descendents)\n",
+                    node->identifier.c_str(), node_mut.get_string().c_str(),
+                    gp_node->identifier.c_str(),
+                    (gp_mut.mut_nuc == gp_mut.ref_nuc ? "reversion " : ""),
+                    gp_mut.get_string().c_str(),
+                    ggp_node->identifier.c_str(),
+                    p_node->mutations.front().get_string().c_str(), descendent_count);
+            node->mutations.clear();
+            node->mutations = std::vector<MAT::Mutation>(p_node->mutations);
+            T->move_node(node->identifier, ggp_node->identifier);
+        }
+    }
+    return descendent_count + 1;
+}
+
+static void fix_grandparent_reversions(MAT::Tree *T, int iterations, int min_descendent_count) {
+    // Find and fix nodes that reverse their grandparent's mutation.
+    // For each case of N > A > B > revA, move revA to N > B (if N > B already exists then move all
+    // children of revA to N > B).
+    int i;
+    for (i = 0;  i < iterations;  i++) {
+        fix_grandparent_reversions_r(T, T->root, NULL, NULL, NULL, min_descendent_count);
+    }
+}
+
+void fix_main(po::parsed_options parsed) {
+    po::variables_map vm = parse_fix_command(parsed);
+    std::string input_mat_filename = vm["input-mat"].as<std::string>();
+    std::string output_mat_filename = vm["output-mat"].as<std::string>();
+    int iterations = vm["iterations"].as<int>();
+    int min_descendent_count = vm["min-descendent-count"].as<int>();
+
+    // Load the input MAT
+    timer.Start();
+    fprintf(stderr, "Loading input MAT file %s.\n", input_mat_filename.c_str());
+    MAT::Tree T = MAT::load_mutation_annotated_tree(input_mat_filename);
+    fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
+
+    // No need to uncondense the tree
+
+    timer.Start();
+    fprintf(stderr, "Fixing grandparent-reversions\n");
+    fix_grandparent_reversions(&T, iterations, min_descendent_count);
+    fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
+
+    timer.Start();
+    fprintf(stderr, "Saving Final Tree\n");
+    MAT::save_mutation_annotated_tree(T, output_mat_filename);
+    fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
+}

--- a/src/matUtils/fix.hpp
+++ b/src/matUtils/fix.hpp
@@ -1,0 +1,3 @@
+#include "common.hpp"
+
+void fix_main(po::parsed_options parsed);

--- a/src/matUtils/main.cpp
+++ b/src/matUtils/main.cpp
@@ -4,6 +4,7 @@
 #include "extract.hpp"
 #include "merge.hpp"
 #include "introduce.hpp"
+#include "fix.hpp"
 #include "version.hpp"
 #include <cstddef>
 
@@ -12,7 +13,7 @@ Timer timer;
 int main (int argc, char** argv) {
     po::options_description global("Command options");
     global.add_options()
-    ("command", po::value<std::string>(), "Command to execute. Valid options are annotate, mask, extract, uncertainty, and summary.")
+    ("command", po::value<std::string>(), "Command to execute. Valid options are annotate, mask, extract, uncertainty, introduce, fix, merge, version, and summary.")
     ("subargs", po::value<std::vector<std::string> >(), "Command-specific arguments.");
     po::positional_options_description pos;
     pos.add("command",1 ).add("subargs", -1);
@@ -20,7 +21,7 @@ int main (int argc, char** argv) {
     po::variables_map vm;
     po::parsed_options parsed = po::command_line_parser(argc, argv).options(global).positional(pos).allow_unregistered().run();
     //this help string shows up over and over, lets just define it once
-    std::string cnames[] = {"COMMAND","summary","extract","annotate","uncertainty","introduce", "merge", "mask", "version"};
+    std::string cnames[] = {"COMMAND","summary","extract","annotate","uncertainty","introduce", "merge", "mask", "fix", "version"};
     std::string chelp[] = {
         "DESCRIPTION\n\n",
         "calculates basic statistics and counts samples, mutations, and clades in the input MAT\n\n",
@@ -30,6 +31,7 @@ int main (int argc, char** argv) {
         "given sample region information, heuristically identifies points of geographic introduction along the phylogeny\n\n",
         "merge all samples of two input MAT files into a single output MAT \n\n",
         "masks the input samples\n\n",
+        "fixes grandparent-reversion structures\n\n",
         "display version number\n\n"
     };
     try {
@@ -57,6 +59,8 @@ int main (int argc, char** argv) {
         introduce_main(parsed);
     } else if (cmd == "mask") {
         mask_main(parsed);
+    } else if (cmd == "fix") {
+        fix_main(parsed);
     } else if (cmd == "version") {
         std::cerr << "matUtils (v" << PROJECT_VERSION << ")" << std::endl;
     } else if (cmd == "help") {

--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -759,6 +759,27 @@ void Mutation_Annotated_Tree::Node::clear_annotations() {
     clade_annotations.clear();
 }
 
+Mutation_Annotated_Tree::Node* Mutation_Annotated_Tree::Node::find_child_with_muts(std::vector<Mutation_Annotated_Tree::Mutation> &muts) {
+    // If this node has a child with the same mutations as passed-in muts, then return that child;
+    // otherwise return NULL.  This sorts muts and some children's mutations if not already sorted.
+    if (! std::is_sorted(muts.begin(), muts.end())) {
+        std::sort(muts.begin(), muts.end());
+    }
+    size_t muts_size = muts.size();
+    for (Mutation_Annotated_Tree::Node* child: children) {
+        if (child->mutations.size() == muts_size) {
+            if (muts_size > 1 &&
+                ! std::is_sorted(child->mutations.begin(), child->mutations.end())) {
+                std::sort(child->mutations.begin(), child->mutations.end());
+            }
+            if (child->mutations == muts) {
+                return child;
+            }
+        }
+    }
+    return NULL;
+}
+
 /* === Tree === */
 size_t Mutation_Annotated_Tree::Tree::get_max_level () const {
     size_t max_level = 0;
@@ -1088,32 +1109,115 @@ void Mutation_Annotated_Tree::Tree::remove_single_child_nodes() {
     }
 }
 
+static void link_parent_child(Mutation_Annotated_Tree::Node *parent,
+                              Mutation_Annotated_Tree::Node *child) {
+    // Establish parent-child links between the given nodes and invalidate child's branch length.
+    child->parent = parent;
+    child->branch_length = -1.0;
+    parent->children.push_back(child);
+}
+
+static void remove_child(Mutation_Annotated_Tree::Tree *T, Mutation_Annotated_Tree::Node *parent,
+                         Mutation_Annotated_Tree::Node *child, bool move_level) {
+    // Remove child from parent; if parent has no remaining children, remove parent from tree.
+    auto iter = std::find(parent->children.begin(), parent->children.end(), child);
+    if (iter == parent->children.end()) {
+        fprintf(stderr, "ERROR: child %s not found in parent %s's children\n",
+                child->identifier.c_str(), parent->identifier.c_str());
+        exit(1);
+    }
+    parent->children.erase(iter);
+    if (parent->children.size() == 0) {
+        T->remove_node(parent->identifier, move_level);
+    }
+}
+
 void Mutation_Annotated_Tree::Tree::move_node (std::string source_id, std::string dest_id, bool move_level) {
+    // Move source to become a child of destination, update all affected nodes' parent pointers and
+    // child lists, and recalculate levels if necessary.
     Node* source = all_nodes[source_id];
     Node* destination = all_nodes[dest_id];
     Node* curr_parent = source->parent;
+    if (curr_parent == destination) {
+        fprintf(stderr, "ERROR: move_node: dest_id=%s but that is already parent of source_id=%s\n",
+                dest_id.c_str(), source_id.c_str());
+        exit(1);
+    }
+    // Node(s) whose level will need to be recalculated after move
+    std::queue<Node*> need_level_update;
 
-    source->parent = destination;
-    source->branch_length = -1.0; // Invalidate source branch length
-
-    destination->children.push_back(source);
-
-    // Remove source from curr_parent
-    auto iter = std::find(curr_parent->children.begin(), curr_parent->children.end(), source);
-    curr_parent->children.erase(iter);
-    if (curr_parent->children.size() == 0) {
-        remove_node(curr_parent->identifier, move_level);
+    // Check for existing child of destination with same mutations as source.
+    Node* dest_existing = destination->find_child_with_muts(source->mutations);
+    if (dest_existing == curr_parent || source->mutations.size() == 0) {
+        dest_existing = NULL;
+    }
+    if (dest_existing == NULL) {
+        // No match with current children of destination; source simply becomes child of destination.
+        link_parent_child(destination, source);
+        remove_child(this, curr_parent, source, move_level);
+        need_level_update.push(source);
+    } else {
+        // destination already has a child with the same non-empty set of mutations as source.
+        // If we simply move source to become a new child of destination then there will be
+        // duplicate children with the same mutations, so don't do that.  The right thing to
+        // do depends on whether source and the existing child are leaf or internal nodes.
+        if (dest_existing->is_leaf()) {
+           if (source->is_leaf()) {
+               // Both source and existing child are leaves; make a new internal node child of
+               // destination with source->mutations and move the leaves to become its children
+               // with no additional mutations.
+               Node *new_internal = create_node(new_internal_node_id(), destination, -1.0);
+               for (auto mut: source->mutations) {
+                   new_internal->add_mutation(mut);
+               }
+               source->mutations.clear();
+               dest_existing->mutations.clear();
+               link_parent_child(new_internal, source);
+               link_parent_child(new_internal, dest_existing);
+               remove_child(this, destination, dest_existing, move_level);
+               remove_child(this, curr_parent, source, move_level);
+               need_level_update.push(new_internal);
+            } else {
+               // source is an internal node and existing child is a leaf; move existing child
+               // into source with no additional mutations and move source into destination.
+               dest_existing->mutations.clear();
+               link_parent_child(source, dest_existing);
+               link_parent_child(destination, source);
+               remove_child(this, destination, dest_existing, move_level);
+               remove_child(this, curr_parent, source, move_level);
+               need_level_update.push(source);
+            }
+        } else {
+            if (source->is_leaf()) {
+                // Existing child is an internal node and source is a leaf; move source into
+                // existing child with no additional mutations.
+                source->mutations.clear();
+                link_parent_child(dest_existing, source);
+                remove_child(this, curr_parent, source, move_level);
+                need_level_update.push(source);
+            } else {
+                // Both source and existing child are internal nodes; move all of source's children
+                // to become children of destination's existing child.
+                // Make copy of source->children vector because the loop removes elements from it
+                auto source_children = source->children;
+                for (auto source_child: source_children) {
+                    // It's not sufficient to link/remove/update here because some of these children
+                    // might have the same mutations as existing children of dest_existing; recurse.
+                    move_node(source_child->identifier, dest_existing->identifier, move_level);
+                }
+                // Removing all children causes source to be removed from tree, so no need to
+                // remove source from curr_parent.
+            }
+        }
     }
 
-    // Update levels of source descendants
-    std::queue<Node*> remaining_nodes;
-    remaining_nodes.push(source);
-    while (remaining_nodes.size() > 0) {
-        Node* curr_node = remaining_nodes.front();
-        remaining_nodes.pop();
+    // Update levels of moved node(s) and descendants
+    while (need_level_update.size() > 0) {
+        Node* curr_node = need_level_update.front();
+        need_level_update.pop();
         curr_node->level = curr_node->parent->level + 1;
         for (auto c: curr_node->children) {
-            remaining_nodes.push(c);
+            need_level_update.push(c);
         }
     }
 }
@@ -1277,35 +1381,46 @@ void Mutation_Annotated_Tree::Tree::uncondense_leaves() {
     condensed_leaves.clear();
 }
 
-void Mutation_Annotated_Tree::Tree::collapse_tree() {
-    auto bfs = breadth_first_expansion();
-
-    for (size_t idx = 1; idx < bfs.size(); idx++) {
-        auto node = bfs[idx];
-        auto mutations = node->mutations;
-        if (mutations.size() == 0) {
-            auto parent = node->parent;
-            auto children = node->children;
-            for (auto child: children) {
-                move_node(child->identifier, parent->identifier, false);
-            }
+static void collapse_tree_r(Mutation_Annotated_Tree::Tree *T, Mutation_Annotated_Tree::Node *node) {
+    // Recursively find nodes with no mutations and move their children up to their parents.
+    // Moved nodes may be removed (if their mutations are redundant with an existing child of
+    // grandparent) so make changes starting from leafmost nodes back to root to avoid referencing
+    // removed nodes.
+    if (node->children.size() > 0) {
+        // Collapse each child of node before deciding what to do with node.
+        // Make a copy of node->children because it can be modified in the loop:
+        auto node_children = node->children;
+        for (auto child: node_children) {
+            collapse_tree_r(T, child);
         }
-        //If internal node has one child, the child can be moved up one level
-        else if (node->children.size() == 1) {
-            auto child = node->children.front();
-            // Preserve chronological order expected by add_mutation by adding child's mutations
-            // to node instead of vice versa, then move node's updated mutations to child.
-            for (auto m: child->mutations) {
-                node->add_mutation(m.copy());
+        auto parent = node->parent;
+        if (parent != NULL) {
+            if (node->mutations.size() == 0) {
+                  auto node_children = node->children;
+                  for (auto child: node_children) {
+                      T->move_node(child->identifier, parent->identifier, false);
+                  }
             }
-            child->mutations.clear();
-            for (auto m: node->mutations) {
-                child->mutations.emplace_back(m.copy());
+            //If internal node has one child, the child can be moved up one level
+            else if (node->children.size() == 1) {
+                auto child = node->children.front();
+                // Preserve chronological order expected by add_mutation by adding child's mutations
+                // to node instead of vice versa, then move node's updated mutations to child.
+                for (auto m: child->mutations) {
+                    node->add_mutation(m.copy());
+                }
+                child->mutations.clear();
+                for (auto m: node->mutations) {
+                    child->mutations.emplace_back(m.copy());
+                }
+                T->move_node(child->identifier, parent->identifier, false);
             }
-            auto parent = node->parent;
-            move_node(child->identifier, parent->identifier, false);
         }
     }
+}
+
+void Mutation_Annotated_Tree::Tree::collapse_tree() {
+    collapse_tree_r(this, this->root);
 }
 
 void Mutation_Annotated_Tree::Tree::rotate_for_display(bool reverse) {

--- a/src/mutation_annotated_tree.hpp
+++ b/src/mutation_annotated_tree.hpp
@@ -51,6 +51,13 @@ struct Mutation {
     inline bool operator< (const Mutation& m) const {
         return ((*this).position < m.position);
     }
+    inline bool operator== (const Mutation& m) const {
+      return ((*this).position == m.position &&
+              (*this).is_missing == m.is_missing &&
+              (*this).chrom == m.chrom &&
+              (*this).par_nuc == m.par_nuc &&
+              (*this).mut_nuc == m.mut_nuc);
+    }
     inline Mutation copy() const {
         Mutation m;
         m.chrom = chrom;
@@ -99,6 +106,7 @@ class Node {
     void add_mutation(Mutation mut);
     void clear_mutations();
     void clear_annotations();
+    Mutation_Annotated_Tree::Node* find_child_with_muts(std::vector<Mutation> &muts);
 };
 
 class Tree {


### PR DESCRIPTION
This bundles several improvements to matUtils.  Let me know if you would prefer for them to be pulled out into separate PRs.

1. I added a new subcommand `fix` to find and fix a recurring pattern that causes trouble for lineage designation: often there is a node whose mutation is simply a reversion of its grandparent's mutation, for example the final node in a path like this:
`... > A1C > G2T > C3A > T2G`
In that case it would be preferable to move that final node to `... > A1C > C3A`, i.e. to move it to become a child of its great-grandparent with only its parent's mutation.  As long as the grandparent, parent and final node all have only one mutation each, that operation is parsimony-preserving.  It represents two independent occurrences of C3A on the A1C branch, as opposed to only one occurrence of C3A followed by an immediate reversion of the previous mutation in the path.  This is motivated by the Pango lineage team's experience of SARS-CoV-2 with advantageous Spike mutations occurring multiple times and causing an increase in transmissions.

2. I found that MAT::Tree::collapse_tree was moving nodes without first looking to see if the new parent node already had a child with the same mutation(s) as the incoming node.  This could result in the new parent node having multiple children with the same mutation(s), which causes incorrect structure and trouble for correctly annotating lineages.  So I updated MAT::Tree:move_node to first search the new parent node's children for the same mutations as the moved node.  Both the existing child and the moved node could be either an internal node or a leaf node (sample); all combinations are handled.  When both nodes are internal nodes, the children of the moved node become children of the new parent's existing child, and the moved node is then removed.  Since the moved node might be removed, MAT::Tree::collapse_tree could no longer use BFS order, so I changed it to start with the deepest nodes and work back towards root.

3. `mask --move-nodes` used to require that the new parent have exactly the same set of mutations as the original parent.  I added support for a new parent with a strict subset of the original parent's mutations, adding the original parent's extra mutations to the moved node.  [Then I could manually make moves like the new `fix` subcommand's moves.  I implemented this before `fix`, for testing.]  I also found that `mask --mask-mutations` was doing more copying than necessary and sped it up a bit.