### PR TITLE
Fix auspice radial and unrooted views

### DIFF
--- a/src/matUtils/convert.cpp
+++ b/src/matUtils/convert.cpp
@@ -520,6 +520,7 @@ void write_json_from_mat(MAT::Tree* T, std::string output_filename, std::vector<
         {
             "tree",{
                 {"name","wrapper"},
+                {"node_attrs",{ {"div",0} }}
             }
         }
     };


### PR DESCRIPTION
Addresses https://github.com/nextstrain/auspice/issues/1756 from the matUtils side by providing a (bogus) divergence value when converting to JSON. This makes the resulting JSON align closer to the schema that Auspice expects, and this enables radial and unrooted view to work properly.

Thanks to @jameshadfield for pinpointing exactly what was missing from the matUtils JSON, and @kvargha for finding the very silly Dockerfile issue that was preventing me from testing my changes properly!