### PR TITLE
Update base image, fix #370

### DIFF
--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     git wget \
     ca-certificates \
     sudo python3 python3-pip
-RUN apt-get upgrade -y sed
 # faSomeRecords and faSize are needed for the UShER WDL workflow 
 WORKDIR /HOME/kentsource
 RUN wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faSomeRecords

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
 ENV DEBIAN_FRONTEND=noninteractive
 USER root
@@ -6,6 +6,8 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     git wget \
     ca-certificates \
     sudo python3 python3-pip
+RUN apt-get upgrade -y sed
+# faSomeRecords and faSize are needed for the UShER WDL workflow 
 WORKDIR /HOME/kentsource
 RUN wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faSomeRecords
 RUN wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faSize
@@ -16,6 +18,5 @@ WORKDIR usher
 ## Checkout latest release
 #RUN git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
 RUN ./install/installUbuntu.sh 
-# faSomeRecords and faSize are needed for the UShER WDL workflow 
 ## set the path
 ENV PATH="/HOME/usher/build:/HOME/kentsource:${PATH}"


### PR DESCRIPTION
Updates the Ubuntu base image to in order to upgrade `sed` to 4.8. 22.04 (jammy) was chosen as the new base image as usher does not compile when the base image is set to 24.04 (noble).

I tested the resulting Docker image as described in #370 and confirmed that this fixes that issue, but I did not extensively test other usher functions.