### PR TITLE
Quick fix for matUtils extract writing bad nwks

### DIFF
--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -225,14 +225,9 @@ void Mutation_Annotated_Tree::write_newick_string (std::stringstream& ss, const 
 
     for (auto n: traversal) {
         size_t level = n->level-level_offset;
-        float branch_length = n->branch_length;
-        
-        printf("Level %ld branch_length %f\n", level, branch_length);
-        
-        if (!retain_original_branch_len) {
-            branch_length = static_cast<float>(n->mutations.size());
-            printf("Not retain original branch len, branch_length now %f", branch_length);
-        }
+        //float branch_length = n->branch_length;
+        //band-aid fix that essentially forces !retain_original_branch_len
+        float branch_length = static_cast<float>(n->mutations.size());
         
         if (curr_level < level) {
             if (!prev_open) {

--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -226,9 +226,14 @@ void Mutation_Annotated_Tree::write_newick_string (std::stringstream& ss, const 
     for (auto n: traversal) {
         size_t level = n->level-level_offset;
         float branch_length = n->branch_length;
+        
+        printf("Level %ld branch_length %f\n", level, branch_length);
+        
         if (!retain_original_branch_len) {
             branch_length = static_cast<float>(n->mutations.size());
+            printf("Not retain original branch len, branch_length now %f", branch_length);
         }
+        
         if (curr_level < level) {
             if (!prev_open) {
                 ss << ',';


### PR DESCRIPTION
This sidesteps #392, allowing in the creation of valid PBs and nwks when using `matUtils extract` with `-z` or `-S`.

Possible consequences:
* Branch length might be recalculated more often than it strictly needs to be
* `-E` is basically a no-op