### PR TITLE
Add --write-diff option to matUtils extract

### DIFF
--- a/src/matUtils/convert.cpp
+++ b/src/matUtils/convert.cpp
@@ -319,6 +319,86 @@ void make_vcf (MAT::Tree T, std::string vcf_filepath, bool no_genotypes, std::ve
 }
 
 
+/// MAPLE diff output
+
+void write_one_maple_diff(MAT::Node* node, std::vector<MAT::Mutation*>& mut_stack, std::ostream& diff_file) {
+    // Header is like FASTA, '>' followed by name:
+    diff_file << '>' << node->identifier << '\n';
+    // Write out substitutions ordered by position, accounting for reversions or multiple successive mutations
+    off_t max_pos = 0;
+    for (MAT::Mutation* mut: mut_stack) {
+        if (mut->position > max_pos) {
+            max_pos = mut->position;
+        }
+    }
+    char *refs = new char[max_pos+1];
+    char *alts = new char[max_pos+1];
+    memset(refs, 0, max_pos+1);
+    memset(alts, 0, max_pos+1);
+    for (MAT::Mutation* mut: mut_stack) {
+        if (refs[mut->position] == 0) {
+          refs[mut->position] = std::tolower(MAT::get_nuc(mut->par_nuc));
+        }
+        alts[mut->position] = std::tolower(MAT::get_nuc(mut->mut_nuc));
+    }
+    off_t i;
+    for (i = 1;  i < max_pos+1;  i++) {
+        if (alts[i] != 0 && alts[i] != refs[i]) {
+            diff_file << alts[i] << '\t' << i << '\n';
+        }
+    }
+    delete refs;
+    delete alts;
+}
+
+void make_diff_r(MAT::Node* node, std::vector<MAT::Mutation*>& mut_stack, std::ostream& diff_file, std::set<std::string>& samples_to_include) {
+    // Recursively descend from node, accumulating mutations on the path from root.  When a leaf is
+    // found in samples_to_include, print out its differences from references in MAPLE diff format.
+    size_t start_size = mut_stack.size();
+    for (MAT::Mutation& mut: node->mutations) {
+        mut_stack.push_back(&mut);
+    }
+    if (mut_stack.size() != start_size + node->mutations.size()) {
+      fprintf(stderr, "Error: start_size %lu + mut count %lu != final size %lu\n", start_size, node->mutations.size(), mut_stack.size());
+      exit(1);
+    }
+    for (MAT::Node *child: node->children) {
+        make_diff_r(child, mut_stack, diff_file, samples_to_include);
+    }
+    if (node->is_leaf() && samples_to_include.find(node->identifier) != samples_to_include.end()) {
+        write_one_maple_diff(node, mut_stack, diff_file);
+    }
+    for (auto mut: node->mutations) {
+        mut_stack.pop_back();
+    }
+}
+
+void make_diff (MAT::Tree& T, std::string diff_filename, std::vector<std::string> samples_vec) {
+    std::set<std::string> samples_to_include;
+    if (samples_vec.size() == 0) {
+        auto tv = T.get_leaves_ids();
+        samples_to_include.insert(tv.begin(),tv.end());
+    } else {
+        samples_to_include.insert(samples_vec.begin(), samples_vec.end());
+    }
+    try {
+        std::ofstream outfile(diff_filename, std::ios::out | std::ios::binary);
+        boost::iostreams::filtering_streambuf<boost::iostreams::output> outbuf;
+        if (diff_filename.find(".gz\0") != std::string::npos) {
+            outbuf.push(boost::iostreams::gzip_compressor());
+        }
+        outbuf.push(outfile);
+        std::ostream diff_file(&outbuf);
+        std::vector<MAT::Mutation*> mut_stack;
+        make_diff_r(T.root, mut_stack, diff_file, samples_to_include);
+        boost::iostreams::close(outbuf);
+        outfile.close();
+    } catch (const boost::iostreams::gzip_error& e) {
+        std::cout << e.what() << '\n';
+    }
+}
+
+
 /// JSON functions below
 
 std::string write_mutations(MAT::Node *N) { // writes muts as a list, e.g. "A23403G,G1440A,G23403A,G2891A" for "nuc mutations" under labels

--- a/src/matUtils/convert.hpp
+++ b/src/matUtils/convert.hpp
@@ -1,5 +1,6 @@
 #include "common.hpp"
 
+void make_diff (MAT::Tree& T, std::string diff_filename, std::vector<std::string> samples_vec = {});
 void make_vcf (MAT::Tree T, std::string vcf_filename, bool no_genotypes, std::vector<std::string> samples_vec = {});
 void write_json_from_mat(MAT::Tree* T, std::string output_filename, std::vector<std::unordered_map<std::string,std::unordered_map<std::string,std::string>>>* catmeta, std::string title);
 MAT::Tree load_mat_from_json(std::string json_filename);

--- a/src/matUtils/extract.cpp
+++ b/src/matUtils/extract.cpp
@@ -61,6 +61,8 @@ po::variables_map parse_extract_command(po::parsed_options parsed) {
      "Write the path of mutations defining each clade in the subtree to the target file.")
     ("all-paths,A", po::value<std::string>()->default_value(""),
      "Write mutations assigned to each node in the subtree in depth-first traversal order to the target file.")
+    ("write-diff", po::value<std::string>()->default_value(""),
+     "Write MAPLE diff file representing selected subtree. Default is full tree")
     ("write-vcf,v", po::value<std::string>()->default_value(""),
      "Output VCF file representing selected subtree. Default is full tree")
     ("no-genotypes,n", po::bool_switch(),
@@ -197,6 +199,7 @@ void extract_main (po::parsed_options parsed) {
     std::string closest_relatives_filename = dir_prefix + vm["closest-relatives"].as<std::string>();
     std::string within_dist_filename = dir_prefix + vm["within-distance"].as<std::string>();
     std::string tree_filename = dir_prefix + vm["write-tree"].as<std::string>();
+    std::string diff_filename = dir_prefix + vm["write-diff"].as<std::string>();
     std::string vcf_filename = dir_prefix + vm["write-vcf"].as<std::string>();
     std::string output_mat_filename = dir_prefix + vm["write-mat"].as<std::string>();
     std::string output_tax_filename = dir_prefix + vm["write-taxodium"].as<std::string>();
@@ -218,7 +221,7 @@ void extract_main (po::parsed_options parsed) {
     uint32_t num_threads = vm["threads"].as<uint32_t>();
     //check that at least one of the output filenames (things which take dir_prefix)
     //are set before proceeding.
-    std::vector<std::string> outs = {sample_path_filename, clade_path_filename, all_path_filename, tree_filename, vcf_filename, output_mat_filename, output_tax_filename, json_filename, used_sample_filename};
+    std::vector<std::string> outs = {sample_path_filename, clade_path_filename, all_path_filename, tree_filename, diff_filename, vcf_filename, output_mat_filename, output_tax_filename, json_filename, used_sample_filename};
     if (!std::any_of(outs.begin(), outs.end(), [=](std::string f) {
     return f != dir_prefix;
 }) &&
@@ -829,6 +832,10 @@ usher_single_subtree_size == 0 && usher_minimum_subtrees_size == 0) {
         catmeta.emplace_back(submet);
     }
     //last step is to convert the subtree to other file formats
+    if (diff_filename != dir_prefix) {
+        fprintf(stderr, "Generating MAPLE diff of final tree\n");
+        make_diff(subtree, diff_filename, samples);
+    }
     if (vcf_filename != dir_prefix) {
         fprintf(stderr, "Generating VCF of final tree\n");
         make_vcf(subtree, vcf_filename, no_genotypes, samples);


### PR DESCRIPTION
The new --write-diff option generates a [MAPLE](https://github.com/NicolaDM/MAPLE)/"diff" output file with the substitutions for each sequence in the selected subtree.  I used this recently to make input for [MAPLE/SPRTA](https://github.com/NicolaDM/MAPLE#branch-support) analysis of the UShER tree in https://www.biorxiv.org/content/10.1101/2024.04.29.591666v1 (under review).