### PR TITLE
Error exit when VCF has duplicated samples

### DIFF
--- a/src/matOptimize/import_vcf_fast.cpp
+++ b/src/matOptimize/import_vcf_fast.cpp
@@ -384,6 +384,10 @@ static void process(MAT::Tree& tree,infile_t& fd) {
                 idx_map.push_back(-1);
                 //exit(EXIT_FAILURE);
             } else {
+                if (inserted_samples.count(fields[idx])) {
+                    fprintf(stderr, "ERROR: sample '%s' appears more than once in the VCF header\n", fields[idx].c_str());
+                    exit(EXIT_FAILURE);
+                }
                 auto res=inserted_samples.insert(fields[idx]);
                 if (res.second) {
                     idx_map.push_back(node->bfs_index);

--- a/src/usher-sampled/import_vcf.cpp
+++ b/src/usher-sampled/import_vcf.cpp
@@ -449,8 +449,8 @@ static void process(infile_t &fd, std::vector<Sample_Muts> &sample_mutations,
     for (size_t field_idx = 9; field_idx < fields.size(); field_idx++) {
         auto ins_result=vcf_samples.emplace(fields[field_idx],field_idx);
         if(!ins_result.second) {
-            fprintf(stderr,"sample %s on both column %zu and %zu, taking first column\n",fields[field_idx].c_str(),ins_result.first->second,field_idx);
-            continue;
+            fprintf(stderr,"ERROR: sample '%s' is in both column %zu and %zu of VCF header\n",fields[field_idx].c_str(),ins_result.first->second,field_idx);
+            exit(EXIT_FAILURE);
         }
         auto node=tree.get_node(fields[field_idx]);
         if (node != nullptr) {


### PR DESCRIPTION
matOptimize can hit a SEGV when the same sample name is used for multiple sample columns in VCF, and sample names should be unique in VCF.  Add a test for duplicated samples to matOptimize's VCF-reading code and exit when found.  Change usher-sampled's VCF reader to exit instead of warning and continuing when duplicates are found, so the error can be found as early in the pipeline as possible.