### PR TITLE
matOptimize set_state_from_parent: call new_mut.back() only after adding to new_mut

### DIFF
--- a/src/matOptimize/apply_move/forward_pass.cpp
+++ b/src/matOptimize/apply_move/forward_pass.cpp
@@ -229,10 +229,10 @@ void set_state_from_parent(MAT::Node *node,
                 assert(*ref_iter == new_mut.back());
                 ref_iter++;
 #endif
-            }
-            if (new_state != old_state) {
-                //register state change at this node
-                this_state_altered_out.emplace_back(new_mut.back(), old_state);
+                if (new_state != old_state) {
+                    //register state change at this node
+                    this_state_altered_out.emplace_back(new_mut.back(), old_state);
+                }
             }
             iter++;
         } else {


### PR DESCRIPTION
Hi Yatish, this is the simple fix proposed in #407.  Thanks!