### PR TITLE
RIPPLES Server Integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ AUX_SOURCE_DIRECTORY(src/matOptimize/Profitable_Moves_Enumerators New_Profitable
 AUX_SOURCE_DIRECTORY(src/matOptimize/apply_move patch_tree) 
 AUX_SOURCE_DIRECTORY(src/check_samples_place check_samples_place) 
 file(GLOB MATUTIL_SRCS "src/matUtils/*.cpp" "src/matUtils/*.hpp")
+file(GLOB RIPPLES_SERVER_SRCS "src/ripples_server/*.cpp" "src/ripples_server/*.hpp")
 file(GLOB RIPPLES_SRCS "src/ripples/*.cpp" "src/ripples/*.hpp")
 file(GLOB USHER_SAMPLED_SRCS "src/usher-sampled/static_tree_mapper/*" "src/usher-sampled/*.cpp" "src/usher-sampled/*.hpp")
 file(GLOB RIPPLES_FAST_SRCS "src/ripples/ripples_fast/*.cpp" "src/ripples/ripples_fast/*.hpp")
@@ -77,6 +78,12 @@ if(DEFINED Protobuf_PATH)
         src/mutation_annotated_tree.cpp
         src/usher_mapper.cpp
         ${MATUTIL_SRCS}
+        )
+    
+    add_executable(ripples_server
+        src/mutation_annotated_tree.cpp
+        src/usher_mapper.cpp
+        ${RIPPLES_SERVER_SRCS}
         )
 
     add_executable(ripples
@@ -293,6 +300,14 @@ else()
         ${TAXO_HDRS}
         )
 
+    add_executable(ripples_server
+        src/mutation_annotated_tree.cpp
+        src/usher_mapper.cpp
+        ${RIPPLES_SERVER_SRCS}
+        ${PROTO_SRCS}
+        ${PROTO_HDRS}
+        )
+
     add_executable(ripples
         src/mutation_annotated_tree.cpp
         src/usher_mapper.cpp
@@ -504,6 +519,9 @@ target_include_directories(usher PUBLIC "${PROJECT_BINARY_DIR}")
 
 TARGET_COMPILE_OPTIONS(matUtils PRIVATE -DTBB_SUPPRESS_DEPRECATED_MESSAGES)
 TARGET_LINK_LIBRARIES(matUtils PRIVATE stdc++  ${Boost_LIBRARIES} ${TBB_IMPORTED_TARGETS} ${Protobuf_LIBRARIES}) # OpenMP::OpenMP_CXX)
+
+TARGET_COMPILE_OPTIONS(ripples_server PRIVATE -DTBB_SUPPRESS_DEPRECATED_MESSAGES)
+TARGET_LINK_LIBRARIES(ripples_server PRIVATE stdc++  ${Boost_LIBRARIES} ${TBB_IMPORTED_TARGETS} ${Protobuf_LIBRARIES}) # OpenMP::OpenMP_CXX)
 
 TARGET_LINK_LIBRARIES(ripplesUtils PRIVATE stdc++  ${Boost_LIBRARIES} ${TBB_IMPORTED_TARGETS} ${Protobuf_LIBRARIES}) # OpenMP::OpenMP_CXX)
 TARGET_LINK_LIBRARIES(ripplesInit PRIVATE stdc++  ${Boost_LIBRARIES} ${TBB_IMPORTED_TARGETS} ${Protobuf_LIBRARIES}) # OpenMP::OpenMP_CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ file(GLOB USHER_SAMPLED_SRCS "src/usher-sampled/static_tree_mapper/*" "src/usher
 file(GLOB RIPPLES_FAST_SRCS "src/ripples/ripples_fast/*.cpp" "src/ripples/ripples_fast/*.hpp")
 file(GLOB RIPPLES_UTILS_SRCS "src/ripples/util/*.cpp" "src/ripples/util/*.hpp")
 
+
 set_source_files_properties(src/mutation_annotated_tree.cpp PROPERTIES COMPILE_FLAGS -O3)
 set_source_files_properties(src/usher-sampled/wait_debug.cpp PROPERTIES COMPILE_FLAGS -O0)
 #set_source_files_properties(src/matOptimize/Profitable_Moves_Enumerators/range_tree.cpp PROPERTIES COMPILE_FLAGS -O0)
@@ -84,6 +85,12 @@ if(DEFINED Protobuf_PATH)
         src/mutation_annotated_tree.cpp
         src/usher_mapper.cpp
         src/usher_common.cpp
+        src/ripples/ripples_fast/ripples_runner.cpp
+        src/ripples/ripples_fast/ripples_util.cpp
+        src/ripples/ripples_fast/ripples.cpp
+        src/ripples/ripples_fast/ripple_aux.cpp
+        src/ripples/ripples_fast/ripple_merger.cpp
+        src/ripples/ripples_fast/ripples_mapper.cpp
         ${RIPPLES_SERVER_SRCS}
         )
 
@@ -305,6 +312,12 @@ else()
         src/mutation_annotated_tree.cpp
         src/usher_mapper.cpp
         src/usher_common.cpp
+        src/ripples/ripples_fast/ripples_runner.cpp
+        src/ripples/ripples_fast/ripples_util.cpp
+        src/ripples/ripples_fast/ripples.cpp
+        src/ripples/ripples_fast/ripple_aux.cpp
+        src/ripples/ripples_fast/ripple_merger.cpp
+        src/ripples/ripples_fast/ripples_mapper.cpp
         ${RIPPLES_SERVER_SRCS}
         ${PROTO_SRCS}
         ${PROTO_HDRS}
@@ -523,7 +536,7 @@ TARGET_COMPILE_OPTIONS(matUtils PRIVATE -DTBB_SUPPRESS_DEPRECATED_MESSAGES)
 TARGET_LINK_LIBRARIES(matUtils PRIVATE stdc++  ${Boost_LIBRARIES} ${TBB_IMPORTED_TARGETS} ${Protobuf_LIBRARIES}) # OpenMP::OpenMP_CXX)
 
 TARGET_COMPILE_OPTIONS(ripples_server PRIVATE -DTBB_SUPPRESS_DEPRECATED_MESSAGES)
-TARGET_LINK_LIBRARIES(ripples_server PRIVATE stdc++  ${Boost_LIBRARIES} ${TBB_IMPORTED_TARGETS} ${Protobuf_LIBRARIES}) # OpenMP::OpenMP_CXX)
+TARGET_LINK_LIBRARIES(ripples_server PRIVATE stdc++ ${Boost_LIBRARIES} ${TBB_IMPORTED_TARGETS} ${Protobuf_LIBRARIES}) # OpenMP::OpenMP_CXX)
 
 TARGET_LINK_LIBRARIES(ripplesUtils PRIVATE stdc++  ${Boost_LIBRARIES} ${TBB_IMPORTED_TARGETS} ${Protobuf_LIBRARIES}) # OpenMP::OpenMP_CXX)
 TARGET_LINK_LIBRARIES(ripplesInit PRIVATE stdc++  ${Boost_LIBRARIES} ${TBB_IMPORTED_TARGETS} ${Protobuf_LIBRARIES}) # OpenMP::OpenMP_CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ if(DEFINED Protobuf_PATH)
     add_executable(ripples_server
         src/mutation_annotated_tree.cpp
         src/usher_mapper.cpp
+        src/usher_common.cpp
         ${RIPPLES_SERVER_SRCS}
         )
 
@@ -303,6 +304,7 @@ else()
     add_executable(ripples_server
         src/mutation_annotated_tree.cpp
         src/usher_mapper.cpp
+        src/usher_common.cpp
         ${RIPPLES_SERVER_SRCS}
         ${PROTO_SRCS}
         ${PROTO_HDRS}

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+export PATH=$PATH:$PWD/build
+cd build
+make -j
+cd ../
+
+MAT="../MAT_WEPP/SARS2-WBE/manuscript_art_unseen_10_dec_2023_dist_7/unseen_pruned_public-2023-12-25.all.masked.pb.gz"
+sequences="../MAT_WEPP/SARS2-WBE/manuscript_art_unseen_10_dec_2023_dist_7/haplotype_removal.txt"
+vcf="../MAT_WEPP/SARS2-WBE/manuscript_art_unseen_10_dec_2023_dist_7/my_vcf_samples.vcf"
+
+ripples_server -i ${MAT} -s ${sequences} -v ${vcf} -T 32

--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -1496,7 +1496,7 @@ Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::Tree::fast_tree_copy() {
 
     //Doing BFS traversal of current tree
     int idx = 0;
-    dfs_curr.emplace_back(std::make_tuple(root, -1, std::vector<int>()));
+    dfs_curr.emplace_back(std::make_tuple(root, -1, std::vector<int>(root->children.size())));
     remaining_nodes.push(std::make_pair(root, idx));
 
     while (remaining_nodes.size())
@@ -1509,18 +1509,18 @@ Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::Tree::fast_tree_copy() {
         // Update children indices of current node
         auto& c_idx_vec = std::get<2>(dfs_curr[curr_idx]);
         for (int i = 0; i < (int)curr_node->children.size(); i++)
-            c_idx_vec.emplace_back(idx + i + 1);
+            c_idx_vec[i] = idx + i + 1;
 
         // Update dfs_curr vector
         for (auto c: curr_node->children)
         {
-            dfs_curr.emplace_back(std::make_tuple(c, curr_idx, std::vector<int>()));
+            dfs_curr.emplace_back(std::make_tuple(c, curr_idx, std::vector<int>(c->children.size())));
             remaining_nodes.push(std::make_pair(c, ++idx));
         }
     }
-
+    
     // Reserve space for new tree and link the nodes
-    T_new.nodes_vector.reserve(dfs_curr.size());
+    T_new.nodes_vector.resize(dfs_curr.size());
     T_new.all_nodes.reserve(dfs_curr.size());
 
     static tbb::affinity_partitioner ap;

--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -1525,9 +1525,10 @@ Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::Tree::fast_tree_copy() {
         }
     }
     
-    // Reserve space for new tree and link the nodes
+    // Reserve space for new tree with nodes_vector and all_nodes by initializing with original tree
     T_new.nodes_vector.resize(dfs_curr.size());
     T_new.all_nodes.reserve(dfs_curr.size());
+    T_new.all_nodes = all_nodes;
 
     static tbb::affinity_partitioner ap;
     tbb::parallel_for(tbb::blocked_range<size_t>(0, dfs_curr.size()),
@@ -1544,6 +1545,8 @@ Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::Tree::fast_tree_copy() {
             new_node->identifier = curr_node->identifier;
             new_node->level = curr_node->level;
             new_node->branch_length = curr_node->branch_length;
+            
+            // Update all_nodes
             T_new.all_nodes[curr_node->identifier] = new_node;
             
             // Update children

--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -1629,9 +1629,7 @@ Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::Tree::fast_tree_copy() {
 void Mutation_Annotated_Tree::Tree::update_all_nodes(const std::vector<Node*>& nodes) {
     for (auto n: nodes)
     {
-        if (all_nodes.find(n->identifier) == all_nodes.end()) {
-            all_nodes[n->identifier] = n;
-        }
+        all_nodes[n->identifier] = n;
     }
 }
 

--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -1626,6 +1626,13 @@ Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::Tree::fast_tree_copy() {
     return T_new;
 }
 
+void Mutation_Annotated_Tree::Tree::update_all_nodes(const std::vector<Node*>& nodes) {
+    for (auto n: nodes)
+    {
+        all_nodes[n->identifier] = n;
+    }
+}
+
 Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::get_tree_copy(const Mutation_Annotated_Tree::Tree& tree, const std::string& identifier) {
     TIMEIT();
     auto root = tree.root;

--- a/src/mutation_annotated_tree.cpp
+++ b/src/mutation_annotated_tree.cpp
@@ -1629,7 +1629,9 @@ Mutation_Annotated_Tree::Tree Mutation_Annotated_Tree::Tree::fast_tree_copy() {
 void Mutation_Annotated_Tree::Tree::update_all_nodes(const std::vector<Node*>& nodes) {
     for (auto n: nodes)
     {
-        all_nodes[n->identifier] = n;
+        if (all_nodes.find(n->identifier) == all_nodes.end()) {
+            all_nodes[n->identifier] = n;
+        }
     }
 }
 

--- a/src/mutation_annotated_tree.hpp
+++ b/src/mutation_annotated_tree.hpp
@@ -120,6 +120,16 @@ class Tree {
         root = NULL;
         curr_internal_node = 0;
         all_nodes.clear();
+        nodes_vector.clear();
+    }
+
+    ~Tree() {
+        root = NULL;
+        curr_internal_node = 0;
+        all_nodes.clear();
+        nodes_vector.clear();
+        condensed_nodes.clear();
+        condensed_leaves.clear();
     }
 
     std::string new_internal_node_id() {

--- a/src/mutation_annotated_tree.hpp
+++ b/src/mutation_annotated_tree.hpp
@@ -171,6 +171,9 @@ class Tree {
 
     // Copy Tree Fast
     Tree fast_tree_copy();
+
+    // FIX for updating all_nodes after usher_common
+    void update_all_nodes(const std::vector<Node*>& nodes);
 };
 
 std::string get_newick_string(const Tree& T, bool b1, bool b2, bool b3=false, bool b4=false);

--- a/src/mutation_annotated_tree.hpp
+++ b/src/mutation_annotated_tree.hpp
@@ -114,6 +114,7 @@ class Tree {
     void remove_node_helper (std::string nid, bool move_level);
     void depth_first_expansion_helper(Node* node, std::vector<Node*>& vec) const;
     std::unordered_map <std::string, Node*> all_nodes;
+    std::vector<Node> nodes_vector;
   public:
     Tree() {
         root = NULL;
@@ -157,6 +158,9 @@ class Tree {
     void collapse_tree();
     void rotate_for_display(bool reverse = false);
     void rotate_for_consistency();
+
+    // Copy Tree Fast
+    Tree fast_tree_copy();
 };
 
 std::string get_newick_string(const Tree& T, bool b1, bool b2, bool b3=false, bool b4=false);

--- a/src/ripples/ripples_fast/main.cpp
+++ b/src/ripples/ripples_fast/main.cpp
@@ -1,4 +1,4 @@
-#include "ripples.hpp"
+#include "ripples_util.hpp"
 #include "src/usher_graph.hpp"
 #include "tbb/concurrent_unordered_set.h"
 #include <array>
@@ -8,6 +8,9 @@
 #include <random>
 #include <time.h>
 #include <vector>
+Timer timer;
+
+/*
 #define CHECK_MAPPER
 Timer timer;
 struct idx_hash {
@@ -73,6 +76,8 @@ struct Ripple_Finalizer {
 
     void operator()(Ripple_Result_Pack*) const;
 };
+*/
+
 int main(int argc, char **argv) {
     po::variables_map vm = check_options(argc, argv);
     std::string input_mat_filename = vm["input-mat"].as<std::string>();
@@ -99,7 +104,6 @@ int main(int argc, char **argv) {
     MAT::Tree T = MAT::load_mutation_annotated_tree(input_mat_filename);
     T.uncondense_leaves();
     fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
-    //get_node_cstr(T,"");
     timer.Start();
 
     fprintf(stderr,
@@ -265,6 +269,8 @@ int main(int argc, char **argv) {
 
     fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
 }
+
+/*
 Ripple_Result_Pack* Ripple_Pipeline::operator()(MAT::Node* node_to_consider) const {
     fprintf(stderr, "At node id: %s\n",
             node_to_consider->identifier.c_str());
@@ -294,18 +300,11 @@ Ripple_Result_Pack* Ripple_Pipeline::operator()(MAT::Node* node_to_consider) con
                    min_range, max_range);
     std::vector<Recomb_Interval> temp(std::vector<Recomb_Interval>(valid_pairs_con.begin(),valid_pairs_con.end()));
     std::sort(temp.begin(),temp.end(),interval_sorter());
-    /*       for(auto p: temp) {
-               std::string end_range_high_str = (p.end_range_high == 1e9) ? "GENOME_SIZE" : std::to_string(p.end_range_high);
-                           fprintf(
-                   before_joining_fh,
-                   "%s\t(%i,%i)\t(%i,%s)\t%s\t%s\n",
-                   node_to_consider->identifier.c_str(), p.start_range_low,
-                   p.start_range_high, p.end_range_low, end_range_high_str.c_str(),
-                   p.d.node->identifier.c_str(), p.a.node->identifier.c_str());
-               fflush(before_joining_fh);
-           }*/
     return (new Ripple_Result_Pack{combine_intervals(temp),node_to_consider,orig_parsimony});
 }
+*/
+
+/*
 void Ripple_Finalizer::operator()(Ripple_Result_Pack* result) const {
     // print combined pairs
     auto & valid_pairs=result->intervals;
@@ -346,3 +345,4 @@ void Ripple_Finalizer::operator()(Ripple_Result_Pack* result) const {
     }
     delete result;
 }
+*/

--- a/src/ripples/ripples_fast/ripple_aux.cpp
+++ b/src/ripples/ripples_fast/ripple_aux.cpp
@@ -117,6 +117,8 @@ po::variables_map check_options(int argc, char **argv) {
     }
     return vm;
 }
+
+/*
 size_t check_parallelizable(const MAT::Node *root,
                             std::vector<bool> &do_parallel,
                             size_t parallel_threshold,
@@ -143,3 +145,4 @@ size_t check_parallelizable(const MAT::Node *root,
     }
     return child_counted_size;
 }
+*/

--- a/src/ripples/ripples_fast/ripples.cpp
+++ b/src/ripples/ripples_fast/ripples.cpp
@@ -1,0 +1,28 @@
+#include "ripples.hpp"
+size_t check_parallelizable(const MAT::Node *root,
+                            std::vector<bool> &do_parallel,
+                            size_t parallel_threshold, size_t check_threshold,
+                            unsigned short &tree_height,
+                            std::vector<Mapper_Info> &traversal_track,
+                            unsigned short level) {
+    size_t child_counted_size = 0;
+    if ((root->dfs_end_idx - root->dfs_idx) >= check_threshold) {
+        child_counted_size++;
+        auto cur_idx = traversal_track.size();
+        traversal_track.push_back(
+            Mapper_Info{root->mutations.data(),
+                        root->mutations.data() + root->mutations.size(),
+                        UINT32_MAX, level, root->children.empty()});
+        for (const auto child : root->children) {
+            child_counted_size += check_parallelizable(
+                child, do_parallel, parallel_threshold, check_threshold,
+                tree_height, traversal_track, level + 1);
+        }
+        if (child_counted_size > parallel_threshold) {
+            do_parallel[root->dfs_idx] = true;
+        }
+        traversal_track[cur_idx].sibling_start_idx = traversal_track.size();
+        tree_height = std::max(tree_height, level);
+    }
+    return child_counted_size;
+}

--- a/src/ripples/ripples_fast/ripples.hpp
+++ b/src/ripples/ripples_fast/ripples.hpp
@@ -1,13 +1,14 @@
+#pragma once
 #include <boost/program_options.hpp>
-#include <src/mutation_annotated_tree.hpp>
-#include <signal.h>
 #include <iostream>
+#include <signal.h>
+#include <src/mutation_annotated_tree.hpp>
 
 namespace po = boost::program_options;
 namespace MAT = Mutation_Annotated_Tree;
 struct Mapper_Info {
-    const MAT::Mutation* begin;
-    const MAT::Mutation* end;
+    const MAT::Mutation *begin;
+    const MAT::Mutation *end;
     unsigned int sibling_start_idx;
     unsigned short level;
     bool is_leaf;
@@ -19,19 +20,16 @@ struct Ripples_Mapper_Mut {
     unsigned short mut_idx;
     char curr_mut;
     char dest_mut;
-    inline bool valid() const {
-        return curr_mut != dest_mut;
-    }
+    inline bool valid() const { return curr_mut != dest_mut; }
     Ripples_Mapper_Mut()
         : position(INT_MAX), mut_idx(NULL_MUT_IDX), curr_mut(0), dest_mut(0) {}
     Ripples_Mapper_Mut(const MAT::Mutation &mut, size_t idx)
         : position(mut.position), mut_idx(idx), curr_mut(mut.ref_nuc),
-          dest_mut(mut.mut_nuc) {
-    }
+          dest_mut(mut.mut_nuc) {}
     Ripples_Mapper_Mut(const MAT::Mutation &mut)
         : position(mut.position), mut_idx(NULL_MUT_IDX), curr_mut(mut.mut_nuc),
           dest_mut(mut.ref_nuc) {
-        //assert(mut.par_nuc == mut.ref_nuc);
+        // assert(mut.par_nuc == mut.ref_nuc);
     }
     Ripples_Mapper_Mut(const Ripples_Mapper_Mut &mut, char new_mut)
         : position(mut.position), mut_idx(mut.mut_idx), curr_mut(new_mut),
@@ -45,12 +43,8 @@ class Mut_Count_t {
     void set(unsigned short count_before_exclusive, bool is_self) {
         internal = (is_self << 15) | count_before_exclusive;
     }
-    unsigned short count_before_exclusive() const {
-        return internal & 0x7fff;
-    }
-    unsigned short is_self_counted() const {
-        return (internal >> 15);
-    }
+    unsigned short count_before_exclusive() const { return internal & 0x7fff; }
+    unsigned short is_self_counted() const { return (internal >> 15); }
     unsigned short count_before_inclusive() const {
         return count_before_exclusive() + is_self_counted();
     }
@@ -60,12 +54,12 @@ typedef std::vector<std::vector<Ripples_Mapper_Mut>> Mut_Out_t;
 
 struct Ripples_Mapper_Output_Interface {
     Mut_Count_Out_t mut_count_out;
-    //Mut_Out_t mut_out;
+    // Mut_Out_t mut_out;
     std::vector<char> is_sibling;
 };
 
 struct Pruned_Sample {
-    MAT::Node* sample_name;
+    MAT::Node *sample_name;
     std::vector<MAT::Mutation> sample_mutations;
     std::unordered_set<uint32_t> positions;
 
@@ -73,11 +67,11 @@ struct Pruned_Sample {
     void add_mutation(MAT::Mutation mut);
     Pruned_Sample() {}
 
-    Pruned_Sample(MAT::Node* name);
+    Pruned_Sample(MAT::Node *name);
 };
 
 struct Recomb_Node {
-    const MAT::Node* node;
+    const MAT::Node *node;
     int node_parsimony;
     int parsimony;
     bool is_sibling;
@@ -86,12 +80,12 @@ struct Recomb_Node {
         parsimony = -1;
         is_sibling = false;
     }
-    Recomb_Node(const MAT::Node* node, int np, int p, char s)
+    Recomb_Node(const MAT::Node *node, int np, int p, char s)
         : node(node), node_parsimony(np), parsimony(p), is_sibling(s) {}
     inline bool operator<(const Recomb_Node &n) const {
-        return (
-                   ((*this).parsimony < n.parsimony) ||
-                   ((this->node->identifier < n.node->identifier) && ((*this).parsimony == n.parsimony)));
+        return (((*this).parsimony < n.parsimony) ||
+                ((this->node->identifier < n.node->identifier) &&
+                 ((*this).parsimony == n.parsimony)));
     }
 };
 
@@ -122,26 +116,25 @@ std::vector<Recomb_Interval>
 combine_intervals(std::vector<Recomb_Interval> pair_list);
 po::variables_map check_options(int argc, char **argv);
 void ripples_mapper(const Pruned_Sample &sample,
-                    Ripples_Mapper_Output_Interface &out,
-                    size_t node_size,
-                    const std::vector<int>& idx_map,
-                    const std::vector<bool>& do_parallel,
+                    Ripples_Mapper_Output_Interface &out, size_t node_size,
+                    const std::vector<int> &idx_map,
+                    const std::vector<bool> &do_parallel,
                     const std::vector<Mapper_Info> &traversal_track,
-                    const unsigned short tree_height,
-                    const MAT::Node *root,
-                    const MAT::Node *skip_node) ;
+                    const unsigned short tree_height, const MAT::Node *root,
+                    const MAT::Node *skip_node);
+
 void ripplrs_merger(const Pruned_Sample &pruned_sample,
-                    const std::vector<int> & idx_map,
+                    const std::vector<int> &idx_map,
                     const std::vector<MAT::Node *> &nodes_to_search,
                     size_t node_size, int pasimony_threshold,
                     const MAT::Tree &T,
                     tbb::concurrent_vector<Recomb_Interval> &valid_pairs,
                     const Ripples_Mapper_Output_Interface &out_ifc,
-                    int nthreads, int branch_len, int min_range,
-                    int max_range) ;
+                    int nthreads, int branch_len, int min_range, int max_range);
+
 size_t check_parallelizable(const MAT::Node *root,
                             std::vector<bool> &do_parallel,
-                            size_t parallel_threshold,
-                            size_t check_threshold,
-                            unsigned short& tree_height,
-                            std::vector<Mapper_Info>& traversal_track,unsigned short level);
+                            size_t parallel_threshold, size_t check_threshold,
+                            unsigned short &tree_height,
+                            std::vector<Mapper_Info> &traversal_track,
+                            unsigned short level);

--- a/src/ripples/ripples_fast/ripples_runner.cpp
+++ b/src/ripples/ripples_fast/ripples_runner.cpp
@@ -1,0 +1,1 @@
+#include "ripples_runner.hpp"

--- a/src/ripples/ripples_fast/ripples_runner.hpp
+++ b/src/ripples/ripples_fast/ripples_runner.hpp
@@ -12,8 +12,6 @@
 #include <time.h>
 #include <vector>
 
-//#include <iostream>
-
 struct ripples_runner {
     ripples_runner(MAT::Tree &tree, const std::vector<Missing_Sample> &samples,
                    uint32_t num_threads, uint32_t branch_len, uint32_t num_desc,
@@ -22,7 +20,7 @@ struct ripples_runner {
           branch_len_(branch_len), num_desc_(num_desc), outdir_(outdir) {}
 
     void operator()() {
-        // TODO: Unused constant parameters, could move to cli as defaults
+        // TODO: Unused constant parameters
         int start_idx = -1;
         int end_idx = -1;
         int max_range = 1e7;
@@ -42,7 +40,6 @@ struct ripples_runner {
             nodes_to_consider;
         auto dfs = T.depth_first_expansion();
 
-        // TODO: Parallelize loop
         for (const auto &sample : samples_) {
             for (auto anc : T.rsearch(sample.name, true)) {
                 if (anc->is_root()) {
@@ -51,8 +48,6 @@ struct ripples_runner {
                 nodes_to_consider.insert(anc);
             }
         }
-        //std::cout << "Nodes to consider size: " << nodes_to_consider.size()
-                  //<< '\n';
 
         std::vector<MAT::Node *> nodes_to_consider_vec;
         for (auto elem : nodes_to_consider) {
@@ -140,7 +135,6 @@ struct ripples_runner {
                 e - s);
 
         size_t num_done = 0;
-        // FILE* before_joining_fh=fopen("before_join_test","w");
         std::vector<MAT::Node *>::const_iterator cur_iter =
             nodes_to_consider_vec.begin() + s;
         std::vector<MAT::Node *>::const_iterator end =

--- a/src/ripples/ripples_fast/ripples_runner.hpp
+++ b/src/ripples/ripples_fast/ripples_runner.hpp
@@ -1,0 +1,173 @@
+#pragma once
+
+#include "ripples.hpp"
+#include "ripples_util.hpp"
+#include "src/usher_graph.hpp"
+#include "tbb/concurrent_unordered_set.h"
+#include <array>
+#include <boost/filesystem.hpp>
+#include <fstream>
+#include <memory>
+#include <random>
+#include <time.h>
+#include <vector>
+
+//#include <iostream>
+
+struct ripples_runner {
+    ripples_runner(MAT::Tree &tree, const std::vector<Missing_Sample> &samples,
+                   uint32_t num_threads, uint32_t branch_len, uint32_t num_desc,
+                   const std::string &outdir)
+        : T(tree), samples_(samples), num_threads_(num_threads),
+          branch_len_(branch_len), num_desc_(num_desc), outdir_(outdir) {}
+
+    void operator()() {
+        // TODO: Unused constant parameters, could move to cli as defaults
+        int start_idx = -1;
+        int end_idx = -1;
+        int max_range = 1e7;
+        int min_range = 1e3;
+        int parsimony_improvement = 3;
+
+        Timer timer;
+
+        tbb::task_scheduler_init init(num_threads_);
+        srand(time(NULL));
+        static tbb::affinity_partitioner ap;
+
+        T.uncondense_leaves();
+        timer.Start();
+
+        tbb::concurrent_unordered_set<MAT::Node *, idx_hash, idx_eq>
+            nodes_to_consider;
+        auto dfs = T.depth_first_expansion();
+
+        // TODO: Parallelize loop
+        for (const auto &sample : samples_) {
+            for (auto anc : T.rsearch(sample.name, true)) {
+                if (anc->is_root()) {
+                    continue;
+                }
+                nodes_to_consider.insert(anc);
+            }
+        }
+        //std::cout << "Nodes to consider size: " << nodes_to_consider.size()
+                  //<< '\n';
+
+        std::vector<MAT::Node *> nodes_to_consider_vec;
+        for (auto elem : nodes_to_consider) {
+            nodes_to_consider_vec.emplace_back(elem);
+        }
+        std::sort(nodes_to_consider_vec.begin(), nodes_to_consider_vec.end());
+        std::shuffle(nodes_to_consider_vec.begin(), nodes_to_consider_vec.end(),
+                     std::default_random_engine(0));
+
+        fprintf(stderr, "Found %zu long branches\n", nodes_to_consider.size());
+        fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
+
+        fprintf(stderr, "Creating output files.\n");
+        boost::filesystem::path path(outdir_);
+        if (!boost::filesystem::exists(path)) {
+            boost::filesystem::create_directory(path);
+        }
+
+        path = boost::filesystem::canonical(outdir_);
+        outdir_ = path.generic_string();
+
+        auto desc_filename = outdir_ + "/descendants.tsv";
+        fprintf(stderr,
+                "Creating file %s to write descendants of recombinant nodes\n",
+                desc_filename.c_str());
+        FILE *desc_file = fopen(desc_filename.c_str(), "w");
+        fprintf(desc_file, "#node_id\tdescendants\n");
+
+        auto recomb_filename = outdir_ + "/recombination.tsv";
+        fprintf(stderr, "Creating file %s to write recombination events\n",
+                recomb_filename.c_str());
+        FILE *recomb_file = fopen(recomb_filename.c_str(), "w");
+        fprintf(recomb_file,
+                "#recomb_node_id\tbreakpoint-1_interval\tbreakpoint-2_"
+                "interval\tdonor_"
+                "node_id\tdonor_is_sibling\tdonor_parsimony\tacceptor_node_"
+                "id\tacceptor_is_sibling\tacceptor_parsimony\toriginal_"
+                "parsimony\tmin_"
+                "starting_parsimony\trecomb_parsimony\n");
+        fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
+
+        timer.Start();
+        std::vector<MAT::Node *> nodes_to_search;
+        nodes_to_search.reserve(dfs.size());
+        for (auto &node : dfs) {
+            if ((node->dfs_end_idx - node->dfs_idx) >= num_desc_) {
+                nodes_to_search.push_back(node);
+            }
+        }
+        std::vector<bool> do_parallel(dfs.size(), false);
+        std::vector<Mapper_Info> traversal_track;
+        unsigned short tree_height = 0;
+        check_parallelizable(T.root, do_parallel,
+                             nodes_to_search.size() / num_threads_, num_desc_,
+                             tree_height, traversal_track, 0);
+        std::vector<int> index_map;
+        int node_to_search_idx = 0;
+        index_map.reserve(dfs.size());
+        for (int dfs_idx = 0; dfs_idx < (int)dfs.size(); dfs_idx++) {
+            if (node_to_search_idx != (int)nodes_to_search.size() &&
+                (int)nodes_to_search[node_to_search_idx]->dfs_idx == dfs_idx) {
+                index_map.push_back(node_to_search_idx);
+                node_to_search_idx++;
+            } else {
+                index_map.push_back(-node_to_search_idx);
+            }
+        }
+
+        fprintf(
+            stderr,
+            "%zu out of %zu nodes have enough descendant to be donor/acceptor",
+            nodes_to_search.size(), dfs.size());
+        size_t s = 0, e = nodes_to_consider.size();
+
+        if ((start_idx >= 0) && (end_idx >= 0)) {
+            s = start_idx;
+            if (end_idx <= (int)e) {
+                e = end_idx;
+            }
+        }
+
+        fprintf(stderr,
+                "Running placement individually for %zu branches to identify "
+                "potential recombination events.\n",
+                e - s);
+
+        size_t num_done = 0;
+        // FILE* before_joining_fh=fopen("before_join_test","w");
+        std::vector<MAT::Node *>::const_iterator cur_iter =
+            nodes_to_consider_vec.begin() + s;
+        std::vector<MAT::Node *>::const_iterator end =
+            nodes_to_consider_vec.begin() + e;
+        tbb::parallel_pipeline(
+            4, tbb::make_filter<void, MAT::Node *>(tbb::filter::serial_in_order,
+                                                   next_node{cur_iter, end}) &
+                   tbb::make_filter<MAT::Node *, Ripple_Result_Pack *>(
+                       tbb::filter::parallel,
+                       Ripple_Pipeline{nodes_to_search, do_parallel, index_map,
+                                       branch_len_, min_range, max_range,
+                                       num_threads_, parsimony_improvement, T,
+                                       traversal_track, tree_height}) &
+                   tbb::make_filter<Ripple_Result_Pack *, void>(
+                       tbb::filter::serial_in_order,
+                       Ripple_Finalizer{desc_file, recomb_file, num_done,
+                                        nodes_to_consider_vec.size(), T}));
+        fclose(desc_file);
+        fclose(recomb_file);
+
+        fprintf(stderr, "Completed in %ld msec \n\n", timer.Stop());
+    }
+
+    MAT::Tree &T;
+    const std::vector<Missing_Sample> &samples_;
+    uint32_t num_threads_;
+    uint32_t branch_len_;
+    uint32_t num_desc_;
+    std::string outdir_;
+};

--- a/src/ripples/ripples_fast/ripples_util.cpp
+++ b/src/ripples/ripples_fast/ripples_util.cpp
@@ -1,0 +1,78 @@
+#include "ripples_util.hpp"
+
+inline MAT::Node *get_node_cstr(MAT::Tree &tree, char *name) {
+    return tree.get_node(std::string(name));
+}
+
+Ripple_Result_Pack* Ripple_Pipeline::operator()(MAT::Node* node_to_consider) const {
+    fprintf(stderr, "At node id: %s\n",
+            node_to_consider->identifier.c_str());
+
+    int orig_parsimony = (int)node_to_consider->mutations.size();
+
+    Pruned_Sample pruned_sample(node_to_consider);
+    // Find mutations on the node to prune
+    auto node_to_root = T.rsearch(node_to_consider->identifier, true);
+    for (auto curr : node_to_root) {
+        for (auto m : curr->mutations) {
+            pruned_sample.add_mutation(m);
+        }
+    }
+    auto parsimony_threshold=orig_parsimony - parsimony_improvement;
+    if (parsimony_threshold<0) {
+        return (new Ripple_Result_Pack{std::vector<Recomb_Interval>(),node_to_consider,orig_parsimony});
+    }
+    //==== new mapper
+    Ripples_Mapper_Output_Interface mapper_out;
+    ripples_mapper(pruned_sample, mapper_out, nodes_to_seach.size(),index_map,do_parallel, traversal_track,tree_height,T.root,node_to_consider);
+    //==== END new mapper
+    tbb::concurrent_vector<Recomb_Interval> valid_pairs_con;
+    ripplrs_merger(pruned_sample, index_map,nodes_to_seach, nodes_to_seach.size(),
+                   parsimony_threshold, T,
+                   valid_pairs_con, mapper_out, num_threads, branch_len,
+                   min_range, max_range);
+    std::vector<Recomb_Interval> temp(std::vector<Recomb_Interval>(valid_pairs_con.begin(),valid_pairs_con.end()));
+    std::sort(temp.begin(),temp.end(),interval_sorter());
+    return (new Ripple_Result_Pack{combine_intervals(temp),node_to_consider,orig_parsimony});
+}
+
+void Ripple_Finalizer::operator()(Ripple_Result_Pack* result) const {
+    // print combined pairs
+    auto & valid_pairs=result->intervals;
+    auto node_to_consider=result->node_to_consider;
+    auto orig_parsimony=result->orig_parsimony;
+    for (auto p : valid_pairs) {
+        std::string end_range_high_str =
+            (p.end_range_high == 1e9) ? "GENOME_SIZE"
+            : std::to_string(p.end_range_high);
+        auto donor_adj_parsimony=p.d.node_parsimony+!p.d.is_sibling;
+        auto acceptor_adj_parsimony=p.a.node_parsimony+!p.a.is_sibling;
+        fprintf(
+            recomb_file,
+            "%s\t(%i,%i)\t(%i,%s)\t%s\t%c\t%i\t%s\t%c\t%i\t%i\t%i\t%i\n",
+            node_to_consider->identifier.c_str(), p.start_range_low,
+            p.start_range_high, p.end_range_low, end_range_high_str.c_str(),
+            p.d.node->identifier.c_str(), p.d.is_sibling?'y':'n',
+            donor_adj_parsimony, p.a.node->identifier.c_str(),
+            p.a.is_sibling?'y':'n', acceptor_adj_parsimony, orig_parsimony,
+            std::min(
+        {orig_parsimony, donor_adj_parsimony, acceptor_adj_parsimony}),
+        p.d.parsimony + p.a.parsimony);
+        fflush(recomb_file);
+    }
+
+    if (!valid_pairs.empty()) {
+        fprintf(desc_file, "%s\t", node_to_consider->identifier.c_str());
+        for (auto l : T.get_leaves(node_to_consider->identifier)) {
+            fprintf(desc_file, "%s,", l->identifier.c_str());
+        }
+        fprintf(desc_file, "\n");
+        fflush(desc_file);
+        fprintf(stderr, "Done %zu/%zu branches [RECOMBINATION FOUND!]\n\n",
+                ++num_done, total_size);
+    } else {
+        fprintf(stderr, "Done %zu/%zu branches\n\n", ++num_done,
+                total_size);
+    }
+    delete result;
+}

--- a/src/ripples/ripples_fast/ripples_util.hpp
+++ b/src/ripples/ripples_fast/ripples_util.hpp
@@ -1,0 +1,81 @@
+#pragma once
+#include "ripples.hpp"
+#include "src/usher_graph.hpp"
+#include "tbb/concurrent_unordered_set.h"
+#include <array>
+#include <boost/filesystem.hpp>
+#include <fstream>
+#include <memory>
+#include <random>
+#include <time.h>
+#include <vector>
+
+#define CHECK_MAPPER
+
+struct idx_hash {
+    size_t operator()(const MAT::Node *in) const { return in->dfs_idx; }
+};
+
+struct idx_eq {
+    bool operator()(const MAT::Node *a, const MAT::Node *b) const {
+        return a->dfs_idx == b->dfs_idx;
+    }
+};
+
+MAT::Node *get_node_cstr(MAT::Tree &tree, char *name);
+
+struct interval_sorter {
+    bool operator()(Recomb_Interval &a, Recomb_Interval &b) {
+        if (a.start_range_high < b.start_range_high) {
+            return true;
+        } else if (a.start_range_high == b.start_range_high &&
+                   a.end_range_low < b.end_range_low) {
+            return true;
+        }
+        return false;
+    }
+};
+
+struct Ripple_Result_Pack {
+    std::vector<Recomb_Interval> intervals;
+    MAT::Node *node_to_consider;
+    int orig_parsimony;
+};
+
+struct next_node {
+    std::vector<MAT::Node *>::const_iterator &iter;
+    std::vector<MAT::Node *>::const_iterator end;
+    MAT::Node *operator()(tbb::flow_control &fc) const {
+        if (iter == end) {
+            fc.stop();
+        }
+        auto to_resturn = *iter;
+        iter++;
+        return to_resturn;
+    }
+};
+
+struct Ripple_Pipeline {
+    const std::vector<MAT::Node *> &nodes_to_seach;
+    const std::vector<bool> &do_parallel;
+    const std::vector<int> &index_map;
+    uint32_t branch_len;
+    int min_range;
+    int max_range;
+    uint32_t num_threads;
+    int parsimony_improvement;
+    MAT::Tree &T;
+    const std::vector<Mapper_Info> &traversal_track;
+    const unsigned short tree_height;
+    Ripple_Result_Pack *operator()(MAT::Node *node_to_consider) const;
+};
+
+struct Ripple_Finalizer {
+    FILE *desc_file;
+    FILE *recomb_file;
+    size_t &num_done;
+    size_t total_size;
+    MAT::Tree &T;
+
+    void operator()(Ripple_Result_Pack *) const;
+};

--- a/src/ripples_server/main.cpp
+++ b/src/ripples_server/main.cpp
@@ -1,0 +1,279 @@
+#include <src/mutation_annotated_tree.hpp>
+#include <algorithm>
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+#include <iostream>
+#include "src/usher_graph.hpp"
+
+namespace po = boost::program_options;
+namespace MAT = Mutation_Annotated_Tree;
+
+int main(int argc, char** argv) {
+    std::string tree_filename;
+    std::string sample_filename;
+    std::string vcf_filename;
+    uint32_t num_threads;
+
+    po::options_description desc("Options");
+    desc.add_options()("input-mat,i", po::value<std::string>(&tree_filename)->required(),
+                       "Input mutation-annotated tree file [REQUIRED].")
+                       ("samples,s", po::value<std::string>(&sample_filename)->required(),
+                       "Select samples by explicitly naming them. One per line [REQUIRED].")
+                       ("read-vcf,v", po::value<std::string>(&vcf_filename)->default_value(""),
+                       "input VCF file containing the samples to be palced")
+                       ("threads,T", po::value<uint32_t>(&num_threads)->default_value(tbb::task_scheduler_init::default_num_threads()),
+                       "Number of Threads to use")
+                       ("help,h", "Print help messages");
+
+
+    po::options_description all_options;
+    all_options.add(desc);
+
+    po::variables_map vm;
+    try {
+        po::store(po::command_line_parser(argc, argv).options(all_options).run(), vm);
+        po::notify(vm);
+    } catch(std::exception &e) {
+        std::cerr << desc << std::endl;
+        // Return with error code 1 unless the user specifies help or version
+        if(vm.count("help"))
+            return 0;
+        else
+            return 1;
+    }
+        
+    fprintf(stderr, "\nInitializing %u worker threads.\n\n", num_threads);
+    tbb::task_scheduler_init init(num_threads);
+
+    Timer timer;
+    MAT::Tree T;
+
+    // Load mutation-annotated tree
+    timer.Start();
+    fprintf(stderr, "Loading existing mutation-annotated tree from file %s\n", tree_filename.c_str());
+    T = MAT::load_mutation_annotated_tree(tree_filename);
+
+    if (T.root == NULL) {
+        fprintf(stderr, "ERROR: Empty tree.\n");
+        exit(1);
+    }
+
+    T.uncondense_leaves();
+    fprintf(stderr, "Tree loaded in %ld msec \n\n", timer.Stop());
+    fprintf(stderr, "LEAVES: %ld\n\n", T.get_num_leaves());
+
+    // Loading Sequence List
+    timer.Start();
+    std::vector<std::string> sample_names;
+    std::ifstream infile(sample_filename);
+    if (!infile) {
+        fprintf(stderr, "ERROR: Could not open the file: %s!\n", sample_filename.c_str());
+        exit(1);
+    }
+    
+    fprintf(stderr, "Loading the sequence names from file %s\n", sample_filename.c_str());
+    std::string line;
+    while (std::getline(infile, line)) {
+        std::vector<std::string> words;
+        MAT::string_split(line, words);
+        if (words.size() > 1) {
+            fprintf(stderr, "WARNING: Sequence file %s contains excess columns; ignoring\n", sample_filename.c_str());
+        } else if (words.size() == 0) {
+            fprintf(stderr, "WARNING: Empty line in Sequence file %s; ignoring\n", sample_filename.c_str());
+            continue;
+        }
+        //remove carriage returns from the input to handle windows os
+        auto sname = words[0];
+        if (sname[sname.size()-1] == '\r') {
+            sname = sname.substr(0,sname.size()-1);
+        }
+        sample_names.push_back(std::move(sname));
+    }
+    infile.close();
+    fprintf(stderr, "Sequences loaded in %ld msec \n\n", timer.Stop());
+
+    // Loading Sequences
+    fprintf(stderr, "Loading the sequences from file %s\n", vcf_filename.c_str());
+    std::unordered_map<std::string, std::vector<MAT::Mutation>> samples;
+    if (vcf_filename != "")
+    {
+        timer.Start();
+        boost::filesystem::ifstream fileHandler(vcf_filename);
+        std::string s;
+        bool header_found = false;
+        while (getline(fileHandler, s)) {
+            std::vector<std::string> words;
+            MAT::string_split(s, words);
+            if (words.size() > 1) {
+                //Checking for header
+                if (words[1] == "POS") 
+                {
+                    header_found = true;
+                    //Leave certain fields based on our VCF format
+                    for (int j = 9; j < (int)words.size(); j++)
+                    {
+                        samples.insert(std::make_pair(words[j], std::vector<MAT::Mutation>{}));
+                    }
+                }
+                else if (header_found) 
+                {
+                    std::vector<std::string> alleles;
+                    //Checking for different alleles at a site
+                    MAT::string_split(words[4], ',', alleles);
+                    for (int j = 9; j < (int)words.size(); j++) 
+                    {
+                        int idx = j - 9;
+                        MAT::Mutation m;
+                        m.chrom = words[0];
+                        m.position = std::stoi(words[1]);
+                        //Checking the mutating allele value within the allele sizes
+                        if (std::stoi(words[j]) > int(alleles.size())) 
+                        {
+                            fprintf(stderr, "\n\nVCF ERROR at Position: %d, idx = %d, Allele_id: %d, Alleles_size: %ld\n\n", m.position, idx, std::stoi(words[j]), alleles.size());
+                        }
+                        m.ref_nuc = MAT::get_nuc_id(words[3][0]);
+                        assert((m.ref_nuc & (m.ref_nuc-1)) == 0); //check if it is power of 2
+                        m.par_nuc = m.ref_nuc;
+                        // Alleles such as '.' should be treated as missing
+                        // data. if the word is numeric, it is an index to one
+                        // of the alleles
+                        if (isdigit(words[j][0])) {
+                            int allele_id = std::stoi(words[j]);
+                            if (allele_id > 0) {
+                                std::string allele = alleles[allele_id-1];
+                                if (allele[0] == 'N') {
+                                    m.is_missing = true;
+                                    m.mut_nuc = MAT::get_nuc_id('N');
+                                } 
+                                else {
+                                    auto nuc = MAT::get_nuc_id(allele[0]);
+                                    if (nuc == MAT::get_nuc_id('N')) {
+                                        m.is_missing = true;
+                                    } 
+                                    else {
+                                        m.is_missing = false;
+                                    }
+                                    m.mut_nuc = nuc;
+                                }
+                                samples[words[j]].emplace_back(m);
+                            }
+                        } 
+                        else {
+                            m.is_missing = true;
+                            m.mut_nuc = MAT::get_nuc_id('N');
+                            samples[words[j]].emplace_back(m);
+                        }
+                    }
+                }
+            }
+        }
+
+        fprintf(stderr, "VCF read in %ld msec \n\n", timer.Stop());
+    }
+    else
+        fprintf(stderr, "No VCF file provided! \n\n");
+
+    // Placing the missing sequences on the tree
+    for (auto s: sample_names)
+    {
+        if (T.get_node(s) == NULL)
+        {
+            fprintf(stderr, "%s is missing from tree.\n", s.c_str());
+            
+            // Copying the Tree
+            timer.Start();
+            MAT::Tree T_new;
+            
+            std::queue<std::pair<MAT::Node*, MAT::Node*>> remaining_nodes;
+            std::vector<MAT::Node*> dfs_orig = T.breadth_first_expansion();
+            std::vector<MAT::Node> dfs_new(dfs_orig.size());
+            int idx = 0;
+
+            remaining_nodes.push(std::pair<MAT::Node*, MAT::Node*>(T.root, NULL));
+            while (!remaining_nodes.empty())
+            {
+                MAT::Node* new_node = &dfs_new[idx++];
+                auto orig_node = remaining_nodes.front().first;
+                auto new_node_parent = remaining_nodes.front().second;
+                remaining_nodes.pop();
+                
+                // Create node
+                if (new_node_parent == NULL) {
+                    new_node->identifier = orig_node->identifier;
+                    new_node->parent = NULL;
+                    new_node->level = 1;
+                    new_node->branch_length = orig_node->branch_length;
+                    new_node->mutations.clear();
+                    new_node->clade_annotations.clear();
+                    T_new.root = new_node;
+                }
+                else {
+                    new_node->identifier = orig_node->identifier;
+                    new_node->parent = new_node_parent;
+                    new_node->level = new_node_parent->level + 1;
+                    new_node->branch_length = orig_node->branch_length;
+                    new_node->mutations.clear();
+                    new_node->clade_annotations.clear();
+                    new_node_parent->children.emplace_back(new_node);
+                }
+
+                //Add children to remaining_nodes    
+                for (auto child: orig_node->children) {
+                    remaining_nodes.push(std::pair<MAT::Node*, MAT::Node*>(child, new_node));
+                }
+            }
+            
+            // Adding annotations and mutations
+            static tbb::affinity_partitioner ap;
+            tbb::parallel_for(tbb::blocked_range<size_t>(0, dfs_orig.size()),
+            [&](tbb::blocked_range<size_t> r) {
+                for (size_t k=r.begin(); k<r.end(); ++k) {
+                    auto orig_node = dfs_orig[k];
+                    auto new_node = &dfs_new[k];
+                    // Add clade annotations
+                    new_node->clade_annotations.resize(orig_node->clade_annotations.size()); 
+                    for (size_t i=0; i < orig_node->clade_annotations.size(); i++) {
+                        new_node->clade_annotations[i] = orig_node->clade_annotations[i];
+                    }
+                    // Add mutations
+                    new_node->mutations.resize(orig_node->mutations.size());
+                    for (size_t i=0; i < orig_node->mutations.size(); i++) {
+                        new_node->mutations[i] = orig_node->mutations[i].copy();
+                    }
+                }
+            }, ap);
+
+            fprintf(stderr, "Tree copied in %ld msec \n\n", timer.Stop());
+            fprintf(stderr, "Root children: %ld\n\n", T_new.root->children.size());
+            fprintf(stderr, "LEAVES: %ld\n\n", T_new.get_num_leaves());
+
+            ////CHECK
+            //for (int i = 0; i < dfs_orig.size(); i++)
+            //{
+            //    auto orig_node = dfs_orig[i];
+            //    auto new_node = &dfs_new[i];
+
+            //    if ((orig_node->level == new_node->level) && (orig_node->branch_length == new_node->branch_length) && (orig_node->identifier == new_node->identifier) && (orig_node->clade_annotations[0] == new_node->clade_annotations[0]) && (orig_node->clade_annotations[1] == new_node->clade_annotations[1]) && ((orig_node->parent == NULL) || ((orig_node->parent != NULL) && (orig_node->parent->identifier == new_node->parent->identifier))))
+            //    {
+            //        for (int i = 0; i < orig_node->children.size(); i++)
+            //        {
+            //            if (orig_node->children[i]->identifier != new_node->children[i]->identifier)
+            //                fprintf(stderr, "%s children are not equal", orig_node->identifier.c_str());
+            //        }
+            //        for (int i = 0; i < orig_node->mutations.size(); i++)
+            //        {
+            //            if (orig_node->mutations[i].mut_nuc != new_node->mutations[i].mut_nuc)
+            //                fprintf(stderr, "%s mutations are not equal", orig_node->identifier.c_str());
+            //        }
+            //    }
+            //    else 
+            //    {
+            //        fprintf(stderr, "%s is not equal", orig_node->identifier.c_str());
+            //    }
+            //}
+        }
+        else
+            fprintf(stderr, "WARNING: %s is already present in the tree.\n", s.c_str());
+    }
+
+}

--- a/src/ripples_server/main.cpp
+++ b/src/ripples_server/main.cpp
@@ -222,17 +222,9 @@ int main(int argc, char** argv) {
         }
         
         // FIX for new nodes NOT present in all_nodes
-				/*
-        std::vector<MAT::Node*> new_nodes;
-        for (auto node: T_new.depth_first_expansion()) {
-            if (std::find(sample_names.begin(), sample_names.end(), node->identifier) != sample_names.end()) {
-                new_nodes.push_back(node);
-            }
-        }
-				*/
         T_new.update_all_nodes(T_new.depth_first_expansion());
 
-				// Set ripples-fast parameters TODO: Can be set from cli options with defaults
+				// Set ripples-fast parameters
 				uint32_t branch_len = 3;
         std::string outdir = ".";
         uint32_t num_desc = 10;

--- a/src/ripples_server/main.cpp
+++ b/src/ripples_server/main.cpp
@@ -215,6 +215,15 @@ int main(int argc, char** argv) {
                             false, false, false, false, false,
                             false, false, false, false, false,
                             false, 0, 0, missing_samples, low_confidence_samples, &T_new);
+        
+        // FIX for new nodes NOT present in all_nodes
+        std::vector<MAT::Node*> new_nodes;
+        for (auto node: T_new.depth_first_expansion()) {
+            if (std::find(sample_names.begin(), sample_names.end(), node->identifier) != sample_names.end()) {
+                new_nodes.push_back(node);
+            }
+        }
+        T_new.update_all_nodes(new_nodes);
 
         if(return_val != 0) {
             exit(1);

--- a/src/ripples_server/main.cpp
+++ b/src/ripples_server/main.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include "src/usher_graph.hpp"
 #include "src/usher_common.hpp"
+#include "src/ripples/ripples_fast/ripples_runner.hpp"
 
 namespace po = boost::program_options;
 namespace MAT = Mutation_Annotated_Tree;
@@ -215,19 +216,28 @@ int main(int argc, char** argv) {
                             false, false, false, false, false,
                             false, false, false, false, false,
                             false, 0, 0, missing_samples, low_confidence_samples, &T_new);
+
+        if(return_val != 0) {
+            exit(1);
+        }
         
         // FIX for new nodes NOT present in all_nodes
+				/*
         std::vector<MAT::Node*> new_nodes;
         for (auto node: T_new.depth_first_expansion()) {
             if (std::find(sample_names.begin(), sample_names.end(), node->identifier) != sample_names.end()) {
                 new_nodes.push_back(node);
             }
         }
-        T_new.update_all_nodes(new_nodes);
+				*/
+        T_new.update_all_nodes(T_new.depth_first_expansion());
 
-        if(return_val != 0) {
-            exit(1);
-        }
+				// Set ripples-fast parameters TODO: Can be set from cli options with defaults
+				uint32_t branch_len = 3;
+        std::string outdir = ".";
+        uint32_t num_desc = 10;
+        ripples_runner runner(T_new, missing_samples, num_threads, branch_len,
+                              num_desc, outdir);
+        runner();
     }
-
 }

--- a/src/ripples_server/main.cpp
+++ b/src/ripples_server/main.cpp
@@ -192,9 +192,12 @@ int main(int argc, char** argv) {
         }
         else
         {
-            auto it = std::find(vcf_samples.begin(), vcf_samples.end(), Missing_Sample(s));
+            auto it = std::find_if(vcf_samples.begin(), vcf_samples.end(),
+                       [&](const Missing_Sample& ms) {
+                           return ms.name == s;
+                       });
             if (it != vcf_samples.end()) {
-                missing_samples.emplace_back(s);
+                missing_samples.emplace_back(*it);
             }
         }
     }
@@ -206,13 +209,13 @@ int main(int argc, char** argv) {
         timer.Start();
         MAT::Tree T_new = T.fast_tree_copy();
         fprintf(stderr, "\nTree copied in %ld msec \n\n", timer.Stop());
-        std::vector<std::string> low_confidence_samples;
             
+        std::vector<std::string> low_confidence_samples;
         int return_val = usher_common("", ".", 1, 1e6, 1e6,
                             false, false, false, false, false,
                             false, false, false, false, false,
                             false, 0, 0, missing_samples, low_confidence_samples, &T_new);
-            
+
         if(return_val != 0) {
             exit(1);
         }


### PR DESCRIPTION
An initial approach for the RIPPLES server, including copying the in-memory MAT, placing the missing samples onto the copied MAT, and then searching the copied MAT for recombination using RIPPLES, only considering the missing samples.

Example Command:
`ripples_server -i <MAT.pb> -s <missing_samples.txt>  -v <missing_samples.vcf>`

Test Example can be found here: https://drive.google.com/drive/folders/1klwVL9l0InsVEdvw-mFBKNtRqK8KMSbP?usp=sharing