### PR TITLE
better conda env

### DIFF
--- a/install/environment.yml
+++ b/install/environment.yml
@@ -5,16 +5,16 @@ channels:
   - anaconda
 dependencies:
   - cxx-compiler
-  - cmake<=3.20
-  - protobuf<=3.20.3 
+  - cmake=3.20
+  - protobuf=3.12.4 
   - make
   - autoconf
   - boost-cpp
   - mafft
-  - python
   - git
   - wget
   - rsync
-  - openmpi
+  - openmpi=3.1.0
   - openssh
   - isa-l
+  - libhwloc


### PR DESCRIPTION
My compilation was failing using the provided environment.yml. This one has helped me build usher on 2 separate servers. I'm not sure if protobuf needs to be downgraded that heavily, but it worked for the HPC I use. Feel free to test or modify these dependencies. The most important addition is libhwloc