### PR TITLE
Add nextclade v3.21.1 binary to Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,17 @@ UShER is now a package consisting of a family of programs for rapid phylogenetic
 * **RIPPLES** is a program that uses a phylogenomic technique to rapidly and sensitively detect recombinant nodes and their ancestors in a mutation-annotated tree (MAT).  
 
 
-Please refer to our [wiki](https://usher-wiki.readthedocs.io/) for detailed instructions on installing and using the UShER package. 
+Please refer to our [wiki](https://usher-wiki.readthedocs.io/) for detailed instructions on installing and using the UShER package.
+
+### SOAR UShER Quick Start
+
+```bash
+# Run UShER in an interactive Docker container
+bin/run
+
+# Build and push a new Docker image (maintainers only)
+bin/build
+```
 
 ## Acknowledgement
 

--- a/bin/build
+++ b/bin/build
@@ -1,1 +1,1 @@
-docker build -t efields236/soar-usher:latest --push install/
+docker buildx build --platform=linux/amd64 -t efields236/soar-usher:latest --push install/

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,1 @@
+docker build -t efields236/soar-usher:latest --push install/

--- a/bin/build
+++ b/bin/build
@@ -1,1 +1,1 @@
-docker buildx build --platform=linux/amd64 -t efields236/soar-usher:latest --push install/
+docker buildx build --platform=linux/amd64,linux/arm64 -t efields236/soar-usher:latest --push install/

--- a/bin/run
+++ b/bin/run
@@ -1,0 +1,1 @@
+docker run -t -i efields236/soar-usher:latest /bin/bash

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -12,10 +12,10 @@ RUN wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faSomeRecords
 RUN wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faSize
 RUN chmod 775 *
 WORKDIR /HOME
-RUN git clone https://github.com/yatisht/usher.git 
-WORKDIR usher
+RUN git clone https://github.com/IRS-Project/soar-usher.git
+WORKDIR soar-usher
 ## Checkout latest release
 #RUN git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
 RUN ./install/installUbuntu.sh 
 ## set the path
-ENV PATH="/HOME/usher/build:/HOME/kentsource:${PATH}"
+ENV PATH="/HOME/soar-usher/build:/HOME/kentsource:${PATH}"

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -1,21 +1,24 @@
-FROM ubuntu:22.04
-ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn
-ENV DEBIAN_FRONTEND=noninteractive
-USER root
-RUN apt-get update && apt-get install -yq --no-install-recommends \
-    git wget \
+# ============================
+# SOAR USHER DOCKER IMAGE
+# ============================
+FROM python:3.10-slim-bookworm
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    python3-dev \
+    git \
+    wget \
     ca-certificates \
-    sudo python3 python3-pip
-# faSomeRecords and faSize are needed for the UShER WDL workflow 
-WORKDIR /HOME/kentsource
-RUN wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faSomeRecords
-RUN wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faSize
-RUN chmod 775 *
+    sudo
+
 WORKDIR /HOME
 RUN git clone https://github.com/IRS-Project/soar-usher.git
 WORKDIR soar-usher
-## Checkout latest release
-#RUN git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
-RUN ./install/installUbuntu.sh 
-## set the path
-ENV PATH="/HOME/soar-usher/build:/HOME/kentsource:${PATH}"
+RUN ./install/installUbuntu.sh
+
+WORKDIR /HOME/soar-usher/build
+RUN wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faSomeRecords \
+    && wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faSize \
+    && chmod +x faSomeRecords faSize
+
+ENV PATH="/HOME/soar-usher/build:${PATH}"

--- a/install/Dockerfile
+++ b/install/Dockerfile
@@ -5,11 +5,16 @@ FROM python:3.10-slim-bookworm
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
+    postgresql-client \
+    gcc \
     python3-dev \
+    libpq-dev \
     git \
     wget \
+    build-essential \
     ca-certificates \
-    sudo
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /HOME
 RUN git clone https://github.com/IRS-Project/soar-usher.git
@@ -20,5 +25,9 @@ WORKDIR /HOME/soar-usher/build
 RUN wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faSomeRecords \
     && wget http://hgdownload.soe.ucsc.edu/admin/exe/linux.x86_64/faSize \
     && chmod +x faSomeRecords faSize
+
+RUN wget -q "https://github.com/nextstrain/nextclade/releases/download/v3.21.1/nextclade-x86_64-unknown-linux-musl" \
+    -O /HOME/soar-usher/build/nextclade \
+    && chmod +x /HOME/soar-usher/build/nextclade
 
 ENV PATH="/HOME/soar-usher/build:${PATH}"


### PR DESCRIPTION
## Summary

- Adds nextclade v3.21.1 static binary to the soar-usher Docker image
- Binary is downloaded from the official Nextstrain GitHub releases and placed in `/HOME/soar-usher/build/` (already on `$PATH`)

## Test plan

- Rebuild the Docker image and verify `nextclade --version` returns `3.21.1`