### PR TITLE
socket.cpp: set missing options

### DIFF
--- a/src/usher-sampled/driver/socket.cpp
+++ b/src/usher-sampled/driver/socket.cpp
@@ -390,6 +390,8 @@ std::string get_options(FILE *f, Leader_Thread_Options &options,std::string& ext
     options.out_options.outdir = path.generic_string();
     options.override_mutations = false;
     options.first_n_samples=INT_MAX;
+    options.keep_n_tree = 1;
+    options.out_options.only_one_tree = true;
     return mat_path;
 }
 static void child_proc(int fd, TreeCollectionPtr &trees_ptr) {


### PR DESCRIPTION
Lineage hunters noticed (#434, https://github.com/cov-lineages/pango-designation/issues/3222) that annotations from clades.txt were missing from usher.bio results.  It turned out that usher-sampled-server was not generating clades.txt because [options.out_options.only_one_tree is required](https://github.com/yatisht/usher/blob/0e4b2da4cf4ab70f6d189e438d00c1b7fb52616d/src/usher-sampled/utils.cpp#L704), but it was not set.

usher-sampled/driver/main.cpp has a [default of 1 for options.keep_n_tree](https://github.com/yatisht/usher/blob/0e4b2da4cf4ab70f6d189e438d00c1b7fb52616d/src/usher-sampled/driver/main.cpp#L437), and [sets options.out_options.only_one_tree if keep_n_tree is 1](https://github.com/yatisht/usher/blob/0e4b2da4cf4ab70f6d189e438d00c1b7fb52616d/src/usher-sampled/driver/main.cpp#L330).  However, usher-sampled/driver/socket.cpp did not set those options.

This change adds two lines to socket.cpp to set keep_n_tree to 1 and only_one_tree to true, to match the default behavior of main.cpp.  clades.txt is now generated by the modified usher-sampled-server.  